### PR TITLE
Fix build documentation

### DIFF
--- a/WORKSPACE.example
+++ b/WORKSPACE.example
@@ -1,0 +1,66 @@
+new_git_repository(
+    name = "prometheus_client_model",
+    remote = "https://github.com/prometheus/client_model.git",
+    commit = "e2da43a",
+    build_file_content = """
+cc_library(
+    name = "prometheus_client_model",
+    srcs = [
+        "cpp/metrics.pb.cc",
+    ],
+    hdrs = [
+         "cpp/metrics.pb.h",
+    ],
+    includes = [
+         "cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@protobuf//:protobuf"],
+)
+    """,
+)
+
+git_repository(
+    name = "protobuf",
+    remote = "https://github.com/google/protobuf.git",
+    tag = "v3.0.0",
+    )
+
+new_git_repository(
+    name = "civetweb",
+    remote = "https://github.com/civetweb/civetweb.git",
+    commit = "fbdee74",
+    build_file_content = """
+cc_library(
+    name = "civetweb",
+    srcs = [
+         "src/civetweb.c",
+         "src/CivetServer.cpp",
+    ],
+    hdrs = [
+         "include/civetweb.h",
+         "include/CivetServer.h",
+         "src/md5.inl",
+         "src/handle_form.inl",
+    ],
+    includes = [
+         "include",
+    ],
+    copts = [
+          "-DUSE_IPV6",
+          "-DNDEBUG",
+          "-DNO_CGI",
+          "-DNO_CACHING",
+          "-DNO_SSL",
+          "-DNO_FILES",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+)
+
+git_repository(
+    name = "prometheus_cpp",
+    remote = "https://github.com/jupp0r/prometheus-cpp.git",
+    commit = "9c865b1c1a4234fa063e91225bb228111ee922ac",
+    )


### PR DESCRIPTION
Documentation on how to consume prometheus-cpp provided in the README
were faulty. This change fixes documentation and resolves #25.