### PR TITLE
Make histograms cumulative

### DIFF
--- a/lib/histogram.cc
+++ b/lib/histogram.cc
@@ -29,10 +29,11 @@ io::prometheus::client::Metric Histogram::Collect() {
   histogram->set_sample_count(sample_count);
   histogram->set_sample_sum(sum_.Value());
 
+  auto cumulative_count = 0ULL;
   for (std::size_t i = 0; i < bucket_counts_.size(); i++) {
-    auto& count = bucket_counts_[i];
+    cumulative_count += bucket_counts_[i].Value();
     auto bucket = histogram->add_bucket();
-    bucket->set_cumulative_count(count.Value());
+    bucket->set_cumulative_count(cumulative_count);
     bucket->set_upper_bound(i == bucket_boundaries_.size()
                                 ? std::numeric_limits<double>::infinity()
                                 : bucket_boundaries_[i]);

--- a/tests/histogram_test.cc
+++ b/tests/histogram_test.cc
@@ -47,25 +47,6 @@ TEST_F(HistogramTest, bucket_size) {
   EXPECT_EQ(h.bucket_size(), 3);
 }
 
-TEST_F(HistogramTest, bucket_count) {
-  Histogram histogram{{1, 2}};
-  histogram.Observe(0);
-  histogram.Observe(0.5);
-  histogram.Observe(1.5);
-  histogram.Observe(1.5);
-  histogram.Observe(3);
-  auto metric = histogram.Collect();
-  ASSERT_TRUE(metric.has_histogram());
-  auto h = metric.histogram();
-  ASSERT_EQ(h.bucket_size(), 3);
-  auto firstBucket = h.bucket(0);
-  EXPECT_EQ(firstBucket.cumulative_count(), 2);
-  auto secondBucket = h.bucket(1);
-  EXPECT_EQ(secondBucket.cumulative_count(), 2);
-  auto thirdBucket = h.bucket(2);
-  EXPECT_EQ(thirdBucket.cumulative_count(), 1);
-}
-
 TEST_F(HistogramTest, bucket_bounds) {
   Histogram histogram{{1, 2}};
   auto metric = histogram.Collect();
@@ -77,7 +58,7 @@ TEST_F(HistogramTest, bucket_bounds) {
   EXPECT_EQ(h.bucket(2).upper_bound(), std::numeric_limits<double>::infinity());
 }
 
-TEST_F(HistogramTest, cumulative_bucket_counts_not_reset_by_collection) {
+TEST_F(HistogramTest, bucket_counts_not_reset_by_collection) {
   Histogram histogram{{1, 2}};
   histogram.Observe(1.5);
   histogram.Collect();
@@ -87,4 +68,20 @@ TEST_F(HistogramTest, cumulative_bucket_counts_not_reset_by_collection) {
   auto h = metric.histogram();
   ASSERT_EQ(h.bucket_size(), 3);
   EXPECT_EQ(h.bucket(1).cumulative_count(), 2);
+}
+
+TEST_F(HistogramTest, cumulative_bucket_count) {
+  Histogram histogram{{1, 2}};
+  histogram.Observe(0);
+  histogram.Observe(0.5);
+  histogram.Observe(1.5);
+  histogram.Observe(1.5);
+  histogram.Observe(3);
+  auto metric = histogram.Collect();
+  ASSERT_TRUE(metric.has_histogram());
+  auto h = metric.histogram();
+  ASSERT_EQ(h.bucket_size(), 3);
+  EXPECT_EQ(h.bucket(0).cumulative_count(), 2);
+  EXPECT_EQ(h.bucket(1).cumulative_count(), 4);
+  EXPECT_EQ(h.bucket(2).cumulative_count(), 5);
 }


### PR DESCRIPTION
This change makes histogram collection produce cumulative
histograms[1].  The previous implementation collected non-cumulative
histograms, which did not conform to the prometheus specification[2].

Fixes #43.

[1]: https://en.wikipedia.org/wiki/Histogram#Cumulative_histogram
[2]: https://prometheus.io/docs/concepts/metric_types/#histogram