### PR TITLE
Exposer constructor marked explicit

### DIFF
--- a/include/prometheus/exposer.h
+++ b/include/prometheus/exposer.h
@@ -17,7 +17,7 @@ class MetricsHandler;
 
 class Exposer {
  public:
-  Exposer(const std::string& bind_address);
+  explicit Exposer(const std::string& bind_address);
   ~Exposer();
   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable);
 


### PR DESCRIPTION
Prevents accidental conversion from std::string to Exposer

Relates to issue #51 