### PR TITLE
Remove unused bucket option on histogram builder

### DIFF
--- a/include/prometheus/histogram_builder.h
+++ b/include/prometheus/histogram_builder.h
@@ -23,14 +23,12 @@ class HistogramBuilder {
   HistogramBuilder& Labels(const std::map<std::string, std::string>& labels);
   HistogramBuilder& Name(const std::string&);
   HistogramBuilder& Help(const std::string&);
-  HistogramBuilder& Buckets(const std::vector<double>&);
   Family<Histogram>& Register(Registry&);
 
  private:
   std::map<std::string, std::string> labels_;
   std::string name_;
   std::string help_;
-  std::vector<double> buckets_;
 };
 }
 }

--- a/lib/histogram_builder.cc
+++ b/lib/histogram_builder.cc
@@ -23,12 +23,6 @@ HistogramBuilder& HistogramBuilder::Help(const std::string& help) {
   return *this;
 }
 
-HistogramBuilder& HistogramBuilder::Buckets(
-    const std::vector<double>& buckets) {
-  buckets_ = buckets;
-  return *this;
-}
-
 Family<Histogram>& HistogramBuilder::Register(Registry& registry) {
   return registry.AddHistogram(name_, help_, labels_);
 }


### PR DESCRIPTION
HistogramBuilder did not pass bucket boundaries as a default to
families. I'm removing it, as bucket boundaries can be set
independently when creating histograms from families.

Fixes #46 