### PR TITLE
Reduce number of threads for scrape server

### DIFF
--- a/lib/exposer.cc
+++ b/lib/exposer.cc
@@ -11,7 +11,8 @@
 namespace prometheus {
 
 Exposer::Exposer(const std::string& bind_address, const std::string& uri)
-    : server_(new CivetServer{{"listening_ports", bind_address.c_str()}}),
+    : server_(new CivetServer{
+          {"listening_ports", bind_address.c_str(), "num_threads", "2"}}),
       exposer_registry_(std::make_shared<Registry>()),
       metrics_handler_(
           new detail::MetricsHandler{collectables_, *exposer_registry_}),
@@ -26,4 +27,4 @@ void Exposer::RegisterCollectable(
     const std::weak_ptr<Collectable>& collectable) {
   collectables_.push_back(collectable);
 }
-}
+}  // namespace prometheus


### PR DESCRIPTION
This change reduces the number of threads configured for the embedded
http server that prometheus queries on scrapes. The previous (default)
setting is 50 worker threads, which is excessive and unnecessary for
metrics use cases.