### PR TITLE
support text format required by Prom 2.0

### DIFF
--- a/lib/text_serializer.cc
+++ b/lib/text_serializer.cc
@@ -1,4 +1,5 @@
 #include "text_serializer.h"
+#include <sstream>
 
 namespace prometheus {
 
@@ -6,8 +7,85 @@ std::string TextSerializer::Serialize(
     const std::vector<io::prometheus::client::MetricFamily>& metrics) {
   auto result = std::string{};
   for (auto&& metric : metrics) {
-    result += metric.DebugString() + "\n";
+	result += TextSerializer::CovertToString(metric) + "\n";
   }
   return result;
 }
+
+std::string TextSerializer::LabelStr(
+		io::prometheus::client::Metric& m) {
+	std::string label_str = "";
+	int label_size = m.label_size();
+	for (int j=0; j<label_size; j++) {
+		auto label_pair = m.label(j);
+		if (j == label_size - 1) {
+			label_str = label_str + label_pair.name() + "=\"" + label_pair.value() + "\"";
+		} else {
+			label_str = label_str + label_pair.name() + "=\"" + label_pair.value() + "\",";
+		}
+	}
+	return label_str;
+}
+
+std::string TextSerializer::SingleMetricStr(io::prometheus::client::Metric& m,
+		const std::string& metric_name, 
+		const io::prometheus::client::MetricType type) {
+  using namespace io::prometheus::client;
+  std::string label_str = LabelStr(m);
+  int label_size = m.label_size();
+  std::string ts = m.has_timestamp_ms() ? std::to_string(m.timestamp_ms()) : "";
+
+  if (type == MetricType::HISTOGRAM) {
+	std::string res = "";
+	int bsize = m.histogram().bucket_size();
+	for (int k=0; k<bsize; k++) {
+		auto bucket = m.histogram().bucket(k);
+		std::string line = metric_name + "_bucket{le=\"" + 
+			std::to_string(bucket.upper_bound()) + "\"," + label_str + "} " + 
+			std::to_string(bucket.cumulative_count()) + " " + ts + "\n";
+		res += line;
+	}
+	res += metric_name + "_sum{" + label_str + "} " + 
+		std::to_string(m.histogram().sample_sum()) + "\n";
+	res += metric_name + "_count{" + label_str + "} " + 
+		std::to_string(m.histogram().sample_count()) + "\n";
+	return res;
+  }else if (type == MetricType::SUMMARY) {
+	return "Not supported by now";
+  }else {
+	  std::string value = std::to_string(m.counter().value());
+	if (label_size != 0) {
+		return (metric_name + "{" + LabelStr(m) + "} " + value + " " + ts + "\n");
+	} else {
+		return (metric_name + " " + value + " " + ts + "\n");
+	}
+  }
+}
+
+std::string TextSerializer::CovertToString(
+		const io::prometheus::client::MetricFamily& metric_family) {
+  using namespace io::prometheus::client;
+  auto result = std::string{};
+  auto repeated_field_metric = metric_family.metric();
+  int size = repeated_field_metric.size();
+
+  std::stringstream ss;
+  auto metric_type = metric_family.type();
+  std::string metric_family_name = metric_family.name();
+  if (metric_family.has_help()) {
+	ss << "# HELP " << metric_family_name << " " << metric_family.help() << std::endl;
+  }
+  if (metric_family.has_type()) {
+	ss << "# TYPE " << metric_family_name << " " << 
+		MetricType_Name(metric_type) << std::endl;
+  }
+
+  for (int i=0; i<size; i++) {
+	auto m = repeated_field_metric.Get(i);
+	ss << TextSerializer::SingleMetricStr(m,metric_family_name,metric_type);
+  }
+
+  return ss.str();
+}
+
 }

--- a/lib/text_serializer.h
+++ b/lib/text_serializer.h
@@ -12,5 +12,12 @@ class TextSerializer : public Serializer {
  public:
   std::string Serialize(
       const std::vector<io::prometheus::client::MetricFamily>& metrics);
+
+ private:
+  static std::string CovertToString(const io::prometheus::client::MetricFamily& metric_family);
+  static std::string LabelStr(io::prometheus::client::Metric& m); 
+  static std::string SingleMetricStr(io::prometheus::client::Metric& m,
+		const std::string& metric_name, 
+		const io::prometheus::client::MetricType type);
 };
 }


### PR DESCRIPTION
Hi, jupp0r. As I talked about Prom2 exposition format with you at #68 , I made some changes to support the text format required by Prom 2.0. The basic idea is to replace method `DebugString` with a custom conversion static method `ConvertToString`, in which `MetricFamily` object is parsed into string.  As I test, it acts normally. For example, when accessing /metrics in a browser or use `curl` command, you'll see:

> \# HELP exposer_bytes_transfered bytesTransferred to metrics services
> \# TYPE exposer_bytes_transfered COUNTER
> exposer_bytes_transfered 2884.000000 
> 
> \# HELP exposer_total_scrapes Number of times metrics were scraped
> \# TYPE exposer_total_scrapes COUNTER
> exposer_total_scrapes 1.000000 
> 
> \# HELP exposer_request_latencies Latencies of serving scrape requests, in milliseconds
> \# TYPE exposer_request_latencies HISTOGRAM
> exposer_request_latencies_bucket{le="1.000000",} 0 
> exposer_request_latencies_bucket{le="5.000000",} 1 
> exposer_request_latencies_bucket{le="10.000000",} 1 
> exposer_request_latencies_bucket{le="20.000000",} 1 
> exposer_request_latencies_bucket{le="40.000000",} 1 
> exposer_request_latencies_bucket{le="80.000000",} 1 
> exposer_request_latencies_bucket{le="160.000000",} 1 
> exposer_request_latencies_bucket{le="320.000000",} 1 
> exposer_request_latencies_bucket{le="640.000000",} 1 
> exposer_request_latencies_bucket{le="1280.000000",} 1 
> exposer_request_latencies_bucket{le="2560.000000",} 1 
> exposer_request_latencies_bucket{le="inf",} 1 
> exposer_request_latencies_sum{} 2.000000
> exposer_request_latencies_count{} 1

I'm not quite sure whether it can satisfy the future needs as a prometheus c++ client library. If you have any suggestions, let me know.