### PR TITLE
Histogram boundary value should be inclusive

### DIFF
--- a/lib/histogram.cc
+++ b/lib/histogram.cc
@@ -17,7 +17,7 @@ void Histogram::Observe(double value) {
   auto bucket_index = static_cast<std::size_t>(std::distance(
       bucket_boundaries_.begin(),
       std::find_if(bucket_boundaries_.begin(), bucket_boundaries_.end(),
-                   [value](double boundary) { return boundary > value; })));
+                   [value](double boundary) { return boundary >= value; })));
   sum_.Increment(value);
   bucket_counts_[bucket_index].Increment();
 }

--- a/tests/histogram_test.cc
+++ b/tests/histogram_test.cc
@@ -74,14 +74,16 @@ TEST_F(HistogramTest, cumulative_bucket_count) {
   Histogram histogram{{1, 2}};
   histogram.Observe(0);
   histogram.Observe(0.5);
+  histogram.Observe(1);
   histogram.Observe(1.5);
   histogram.Observe(1.5);
+  histogram.Observe(2);
   histogram.Observe(3);
   auto metric = histogram.Collect();
   ASSERT_TRUE(metric.has_histogram());
   auto h = metric.histogram();
   ASSERT_EQ(h.bucket_size(), 3);
-  EXPECT_EQ(h.bucket(0).cumulative_count(), 2);
-  EXPECT_EQ(h.bucket(1).cumulative_count(), 4);
-  EXPECT_EQ(h.bucket(2).cumulative_count(), 5);
+  EXPECT_EQ(h.bucket(0).cumulative_count(), 3);
+  EXPECT_EQ(h.bucket(1).cumulative_count(), 6);
+  EXPECT_EQ(h.bucket(2).cumulative_count(), 7);
 }


### PR DESCRIPTION
Boundary value should be inclusive to make it consistent with other `Prometheus` clients:

* `Java` https://github.com/prometheus/client_java/blob/fb4161a2be99074f1d2fd254238193afa4aa0398/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L238

* `Golang` https://github.com/prometheus/client_golang/blob/661e31bf844dfca9aeba15f27ea8aa0d485ad212/prometheus/histogram.go#L250 where
```go
func SearchFloat64s(a []float64, x float64) int {
    return Search(len(a), func(i int) bool { return a[i] >= x })
}
```

* `Python` https://github.com/prometheus/client_python/blob/24d4d95d3fee82e1b5d8679b69b340dab5815eed/prometheus_client/core.py#L891

* `Ruby` https://github.com/prometheus/client_ruby/blob/726512562b354995ab4d325bc4f654833eb225e5/lib/prometheus/client/histogram.rb#L29