### PR TITLE
the civet server should be available externally of the exposer

### DIFF
--- a/include/prometheus/exposer.h
+++ b/include/prometheus/exposer.h
@@ -23,8 +23,10 @@ class Exposer {
   ~Exposer();
   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable);
 
+  std::shared_ptr<CivetServer> GetServer();
+
  private:
-  std::unique_ptr<CivetServer> server_;
+  std::shared_ptr<CivetServer> server_;
   std::vector<std::weak_ptr<Collectable>> collectables_;
   std::shared_ptr<Registry> exposer_registry_;
   std::unique_ptr<detail::MetricsHandler> metrics_handler_;

--- a/lib/exposer.cc
+++ b/lib/exposer.cc
@@ -23,6 +23,8 @@ Exposer::Exposer(const std::string& bind_address, const std::string& uri)
 
 Exposer::~Exposer() { server_->removeHandler(uri_); }
 
+std::shared_ptr<CivetServer> Exposer::GetServer() { return server_; }
+
 void Exposer::RegisterCollectable(
     const std::weak_ptr<Collectable>& collectable) {
   collectables_.push_back(collectable);


### PR DESCRIPTION
I would like to have the Civet server available outside of the Exposer class. The reasoning for this is that I would like to add a health check endpoint to my application and I do not want to start a separate web server.