### PR TITLE
WIP: implement summary metric

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -14,6 +14,8 @@ cc_library(
         "lib/json_serializer.cc",
         "lib/protobuf_delimited_serializer.cc",
         "lib/registry.cc",
+        "lib/summary.cc",
+        "lib/summary_builder.cc",
         "lib/text_serializer.cc",
     ],
     hdrs = glob(

--- a/README.md
+++ b/README.md
@@ -207,8 +207,6 @@ Alpha
   number of scrapes, scrape request latencies)
 * there is a working [example](tests/integration/sample_server.cc)
   that prometheus successfully scrapes
-* gauge, counter and histogram metrics are implemented, summaries
-  aren't
 
 ## FAQ
 

--- a/include/prometheus/registry.h
+++ b/include/prometheus/registry.h
@@ -9,6 +9,8 @@
 #include "prometheus/gauge_builder.h"
 #include "prometheus/histogram.h"
 #include "prometheus/histogram_builder.h"
+#include "prometheus/summary.h"
+#include "prometheus/summary_builder.h"
 
 #include "metrics.pb.h"
 
@@ -19,6 +21,7 @@ class Registry : public Collectable {
   friend class detail::CounterBuilder;
   friend class detail::GaugeBuilder;
   friend class detail::HistogramBuilder;
+  friend class detail::SummaryBuilder;
 
   // collectable
   std::vector<io::prometheus::client::MetricFamily> Collect() override;
@@ -31,6 +34,8 @@ class Registry : public Collectable {
   Family<Histogram>& AddHistogram(
       const std::string& name, const std::string& help,
       const std::map<std::string, std::string>& labels);
+  Family<Summary>& AddSummary(const std::string& name, const std::string& help,
+                              const std::map<std::string, std::string>& labels);
 
   std::vector<std::unique_ptr<Collectable>> collectables_;
   std::mutex mutex_;

--- a/include/prometheus/summary.h
+++ b/include/prometheus/summary.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <list>
+#include <mutex>
+#include <vector>
+
+#include "metrics.pb.h"
+
+#include "prometheus/metric.h"
+
+namespace prometheus {
+
+namespace detail {
+class CKMSQuantiles {
+ public:
+  struct Quantile {
+    const double quantile;
+    const double error;
+    const double u;
+    const double v;
+
+    Quantile(double quantile, double error);
+  };
+
+ private:
+  struct Item {
+    /*const*/ double value;
+    int g;
+    /*const*/ int delta;
+
+    explicit Item(double value, int lower_delta, int delta);
+  };
+
+ public:
+  explicit CKMSQuantiles(const std::vector<Quantile>& quantiles);
+
+  void insert(double value);
+  double get(double q);
+  void reset();
+
+ private:
+  double allowableError(int rank);
+  bool insertBatch();
+  void compress();
+
+ private:
+  const std::reference_wrapper<const std::vector<Quantile>> quantiles_;
+
+  std::size_t count_;
+  std::vector<Item> sample_;
+  std::array<double, 500> buffer_;
+  std::size_t buffer_count_;
+};
+
+class TimeWindowQuantiles {
+  using Clock = std::chrono::steady_clock;
+
+ public:
+  TimeWindowQuantiles(const std::vector<CKMSQuantiles::Quantile>& quantiles,
+                      Clock::duration max_age_seconds, int age_buckets);
+
+  double get(double q);
+  void insert(double value);
+
+ private:
+  CKMSQuantiles& rotate();
+
+  const std::vector<CKMSQuantiles::Quantile>& quantiles_;
+  std::vector<CKMSQuantiles> ckms_quantiles_;
+  std::size_t current_bucket_;
+
+  Clock::time_point last_rotation_;
+  const Clock::duration rotation_interval_;
+};
+}  // namespace detail
+
+class Summary : public Metric {
+ public:
+  using Quantiles = std::vector<detail::CKMSQuantiles::Quantile>;
+
+  static const io::prometheus::client::MetricType metric_type =
+      io::prometheus::client::SUMMARY;
+
+  Summary(const Quantiles& quantiles,
+          std::chrono::milliseconds max_age_seconds = std::chrono::seconds(60),
+          int age_buckets = 5);
+
+  void Observe(double value);
+
+  io::prometheus::client::Metric Collect();
+
+ private:
+  const Quantiles quantiles_;
+
+  std::mutex mutex_;
+
+  double count_;
+  double sum_;
+  detail::TimeWindowQuantiles quantile_values_;
+};
+}  // namespace prometheus

--- a/include/prometheus/summary_builder.h
+++ b/include/prometheus/summary_builder.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace prometheus {
+
+template <typename T>
+class Family;
+class Summary;
+class Registry;
+
+namespace detail {
+class SummaryBuilder;
+}
+
+detail::SummaryBuilder BuildSummary();
+
+namespace detail {
+class SummaryBuilder {
+ public:
+  SummaryBuilder& Labels(const std::map<std::string, std::string>& labels);
+  SummaryBuilder& Name(const std::string&);
+  SummaryBuilder& Help(const std::string&);
+  Family<Summary>& Register(Registry&);
+
+ private:
+  std::map<std::string, std::string> labels_;
+  std::string name_;
+  std::string help_;
+};
+}  // namespace detail
+
+}  // namespace prometheus

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(prometheus-cpp
   json_serializer.cc
   protobuf_delimited_serializer.cc
   registry.cc
+  summary.cc
+  summary_builder.cc
   text_serializer.cc
 
   # civetweb

--- a/lib/handler.cc
+++ b/lib/handler.cc
@@ -23,13 +23,12 @@ MetricsHandler::MetricsHandler(
                               .Register(registry)),
       num_scrapes_(num_scrapes_family_.Add({})),
       request_latencies_family_(
-          BuildHistogram()
+          BuildSummary()
               .Name("exposer_request_latencies")
               .Help("Latencies of serving scrape requests, in milliseconds")
               .Register(registry)),
       request_latencies_(request_latencies_family_.Add(
-          {}, Histogram::BucketBoundaries{1, 5, 10, 20, 40, 80, 160, 320, 640,
-                                          1280, 2560})) {}
+          {}, Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}})) {}
 
 static std::string GetAcceptedEncoding(struct mg_connection* conn) {
   auto request_info = mg_get_request_info(conn);

--- a/lib/handler.h
+++ b/lib/handler.h
@@ -24,8 +24,8 @@ class MetricsHandler : public CivetHandler {
   Counter& bytes_transferred_;
   Family<Counter>& num_scrapes_family_;
   Counter& num_scrapes_;
-  Family<Histogram>& request_latencies_family_;
-  Histogram& request_latencies_;
+  Family<Summary>& request_latencies_family_;
+  Summary& request_latencies_;
 };
 }
 }

--- a/lib/registry.cc
+++ b/lib/registry.cc
@@ -29,6 +29,15 @@ Family<Histogram>& Registry::AddHistogram(
   return *histogram_family;
 }
 
+Family<Summary>& Registry::AddSummary(
+    const std::string& name, const std::string& help,
+    const std::map<std::string, std::string>& labels) {
+  std::lock_guard<std::mutex> lock{mutex_};
+  auto histogram_family = new Family<Summary>(name, help, labels);
+  collectables_.push_back(std::unique_ptr<Collectable>{histogram_family});
+  return *histogram_family;
+}
+
 std::vector<io::prometheus::client::MetricFamily> Registry::Collect() {
   std::lock_guard<std::mutex> lock{mutex_};
   auto results = std::vector<io::prometheus::client::MetricFamily>{};

--- a/lib/summary.cc
+++ b/lib/summary.cc
@@ -1,0 +1,201 @@
+#include "prometheus/summary.h"
+
+#include <cmath>
+#include <algorithm>
+
+namespace prometheus {
+
+namespace detail {
+
+CKMSQuantiles::Quantile::Quantile(double quantile, double error)
+    : quantile(quantile),
+      error(error),
+      u(2.0 * error / (1.0 - quantile)),
+      v(2.0 * error / quantile) {}
+
+CKMSQuantiles::Item::Item(double value, int lower_delta, int delta)
+    : value(value), g(lower_delta), delta(delta) {}
+
+CKMSQuantiles::CKMSQuantiles(const std::vector<Quantile>& quantiles)
+    : quantiles_(quantiles), count_(0), buffer_count_(0) {}
+
+void CKMSQuantiles::insert(double value) {
+  buffer_[buffer_count_] = value;
+  ++buffer_count_;
+
+  if (buffer_count_ == buffer_.size()) {
+    insertBatch();
+    compress();
+  }
+}
+
+double CKMSQuantiles::get(double q) {
+  insertBatch();
+  compress();
+
+  if (sample_.empty()) return std::numeric_limits<double>::quiet_NaN();
+
+  int rankMin = 0;
+  const auto desired = static_cast<int>(q * count_);
+  const auto bound = desired + (allowableError(desired) / 2);
+
+  auto it = sample_.begin();
+  decltype(it) prev;
+  auto cur = it++;
+
+  while (it != sample_.end()) {
+    prev = cur;
+    cur = it++;
+
+    rankMin += prev->g;
+
+    if (rankMin + cur->g + cur->delta > bound) return prev->value;
+  }
+
+  return sample_.back().value;
+}
+
+void CKMSQuantiles::reset() {
+  count_ = 0;
+  sample_.clear();
+  buffer_count_ = 0;
+}
+
+double CKMSQuantiles::allowableError(int rank) {
+  auto size = sample_.size();
+  double minError = size + 1;
+
+  for (const auto& q : quantiles_.get()) {
+    double error;
+    if (rank <= q.quantile * size)
+      error = q.u * (size - rank);
+    else
+      error = q.v * rank;
+    if (error < minError) minError = error;
+  }
+
+  return minError;
+}
+
+bool CKMSQuantiles::insertBatch() {
+  if (buffer_count_ == 0) return false;
+
+  std::sort(buffer_.begin(), buffer_.begin() + buffer_count_);
+
+  std::size_t start = 0;
+  if (sample_.empty()) {
+    sample_.emplace_back(buffer_[0], 1, 0);
+    ++start;
+    ++count_;
+  }
+
+  std::size_t idx = 0;
+  std::size_t item = idx++;
+
+  for (std::size_t i = start; i < buffer_count_; ++i) {
+    double v = buffer_[i];
+    while (idx < sample_.size() && sample_[item].value < v) item = idx++;
+
+    if (sample_[item].value > v) --idx;
+
+    int delta;
+    if (idx - 1 == 0 || idx + 1 == sample_.size())
+      delta = 0;
+    else
+      delta = static_cast<int>(std::floor(allowableError(idx + 1))) + 1;
+
+    sample_.emplace(sample_.begin() + idx, v, 1, delta);
+    count_++;
+    item = idx++;
+  }
+
+  buffer_count_ = 0;
+  return true;
+}
+
+void CKMSQuantiles::compress() {
+  if (sample_.size() < 2) return;
+
+  std::size_t idx = 0;
+  std::size_t prev;
+  std::size_t next = idx++;
+
+  while (idx < sample_.size()) {
+    prev = next;
+    next = idx++;
+
+    if (sample_[prev].g + sample_[next].g + sample_[next].delta <=
+        allowableError(idx - 1)) {
+      sample_[next].g += sample_[prev].g;
+      sample_.erase(sample_.begin() + prev);
+    }
+  }
+}
+
+TimeWindowQuantiles::TimeWindowQuantiles(
+    const std::vector<CKMSQuantiles::Quantile>& quantiles,
+    Clock::duration max_age_seconds, int age_buckets)
+    : quantiles_(quantiles),
+      ckms_quantiles_(age_buckets, CKMSQuantiles(quantiles_)),
+      current_bucket_(0),
+      last_rotation_(Clock::now()),
+      rotation_interval_(max_age_seconds / age_buckets) {}
+
+double TimeWindowQuantiles::get(double q) {
+  CKMSQuantiles& current_bucket = rotate();
+  return current_bucket.get(q);
+}
+
+void TimeWindowQuantiles::insert(double value) {
+  rotate();
+  for (auto& bucket : ckms_quantiles_) bucket.insert(value);
+}
+
+CKMSQuantiles& TimeWindowQuantiles::rotate() {
+  auto delta = Clock::now() - last_rotation_;
+  while (delta > rotation_interval_) {
+    ckms_quantiles_[current_bucket_].reset();
+
+    if (++current_bucket_ >= ckms_quantiles_.size()) current_bucket_ = 0;
+
+    delta -= rotation_interval_;
+    last_rotation_ += rotation_interval_;
+  }
+  return ckms_quantiles_[current_bucket_];
+}
+
+}  // namespace detail
+
+Summary::Summary(const Quantiles& quantiles,
+                 std::chrono::milliseconds max_age_seconds, int age_buckets)
+    : quantiles_(quantiles),
+      count_(0),
+      sum_(0),
+      quantile_values_(quantiles_, max_age_seconds, age_buckets) {}
+
+void Summary::Observe(double value) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  count_ += 1;
+  sum_ += value;
+  quantile_values_.insert(value);
+}
+
+io::prometheus::client::Metric Summary::Collect() {
+  auto metric = io::prometheus::client::Metric{};
+  auto summary = metric.mutable_summary();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  for (const auto& quantile : quantiles_) {
+    auto entry = summary->add_quantile();
+    entry->set_quantile(quantile.quantile);
+    entry->set_value(quantile_values_.get(quantile.quantile));
+  }
+  summary->set_sample_count(count_);
+  summary->set_sample_sum(sum_);
+
+  return metric;
+}
+
+}  // namespace prometheus

--- a/lib/summary_builder.cc
+++ b/lib/summary_builder.cc
@@ -1,0 +1,30 @@
+#include "prometheus/summary_builder.h"
+#include "prometheus/registry.h"
+
+namespace prometheus {
+
+detail::SummaryBuilder BuildSummary() { return {}; }
+
+namespace detail {
+
+SummaryBuilder& SummaryBuilder::Labels(
+    const std::map<std::string, std::string>& labels) {
+  labels_ = labels;
+  return *this;
+}
+
+SummaryBuilder& SummaryBuilder::Name(const std::string& name) {
+  name_ = name;
+  return *this;
+}
+
+SummaryBuilder& SummaryBuilder::Help(const std::string& help) {
+  help_ = help;
+  return *this;
+}
+
+Family<Summary>& SummaryBuilder::Register(Registry& registry) {
+  return registry.AddSummary(name_, help_, labels_);
+}
+}  // namespace detail
+}  // namespace prometheus

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -8,6 +8,7 @@ cc_test(
         "histogram_test.cc",
         "mock_metric.h",
         "registry_test.cc",
+        "summary_test.cc",
     ],
     copts = ["-Iexternal/googletest/include"],
     linkstatic = 1,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(prometheus_test
   histogram_test.cc
   mock_metric.h
   registry_test.cc
+  summary_test.cc
 )
 
 target_link_libraries(prometheus_test PRIVATE prometheus-cpp)

--- a/tests/benchmark/BUILD
+++ b/tests/benchmark/BUILD
@@ -8,6 +8,7 @@ cc_binary(
         "histogram_bench.cc",
         "main.cc",
         "registry_bench.cc",
+        "summary_bench.cc",
     ],
     linkstatic = 1,
     deps = [

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(benchmarks
   gauge_bench.cc
   histogram_bench.cc
   registry_bench.cc
+  summary_bench.cc
 )
 
 target_link_libraries(benchmarks PRIVATE prometheus-cpp)

--- a/tests/benchmark/summary_bench.cc
+++ b/tests/benchmark/summary_bench.cc
@@ -1,0 +1,133 @@
+#include <chrono>
+#include <random>
+
+#include <benchmark/benchmark.h>
+#include <prometheus/registry.h>
+
+using prometheus::Summary;
+
+static const auto ITERATIONS = 262144;
+
+static Summary::Quantiles CreateLinearQuantiles(int count) {
+  static auto generator = [](double x) {
+    static auto exp = [](double x) {
+      static const double A = 2;
+      return 1 - std::exp(-A * x);
+    };
+
+    return exp(x) / exp(1);
+  };
+
+  auto quantiles = Summary::Quantiles{};
+  for (auto i = 0; i < count; ++i) {
+    quantiles.emplace_back(generator(double(i) / count), 0.01);
+  }
+  return quantiles;
+}
+
+static void BM_Summary_Observe(benchmark::State& state) {
+  using prometheus::BuildSummary;
+  using prometheus::Registry;
+  using prometheus::Summary;
+
+  const auto number_of_quantiles = state.range(0);
+
+  Registry registry;
+  auto& summary_family =
+      BuildSummary().Name("benchmark_summary").Help("").Register(registry);
+  auto quantiles = CreateLinearQuantiles(number_of_quantiles);
+  auto& summary = summary_family.Add({}, quantiles);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> d(0, 100);
+
+  while (state.KeepRunning()) {
+    auto observation = d(gen);
+    auto start = std::chrono::high_resolution_clock::now();
+    summary.Observe(observation);
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto elapsed_seconds =
+        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
+    state.SetIterationTime(elapsed_seconds.count());
+  }
+}
+BENCHMARK(BM_Summary_Observe)->Range(0, 64)->Iterations(ITERATIONS);
+
+static void BM_Summary_Collect(benchmark::State& state) {
+  using prometheus::BuildSummary;
+  using prometheus::Registry;
+  using prometheus::Summary;
+
+  const auto number_of_quantiles = state.range(0);
+  const auto number_of_entries = state.range(1);
+
+  Registry registry;
+  auto& summary_family =
+      BuildSummary().Name("benchmark_summary").Help("").Register(registry);
+  auto quantiles = CreateLinearQuantiles(number_of_quantiles);
+  auto& summary = summary_family.Add({}, quantiles);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> d(0, 100);
+  for (auto i = 1; i <= number_of_entries; ++i) summary.Observe(d(gen));
+
+  while (state.KeepRunning()) {
+    benchmark::DoNotOptimize(summary.Collect());
+  }
+}
+BENCHMARK(BM_Summary_Collect)->RangePair(0, 64, 0, ITERATIONS);
+
+static void BM_Summary_Observe_Common(benchmark::State& state) {
+  using prometheus::BuildSummary;
+  using prometheus::Registry;
+  using prometheus::Summary;
+
+  Registry registry;
+  auto& summary_family =
+      BuildSummary().Name("benchmark_summary").Help("").Register(registry);
+  auto& summary = summary_family.Add(
+      {}, Summary::Quantiles{
+              {0.5, 0.05}, {0.9, 0.01}, {0.95, 0.005}, {0.99, 0.001}});
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> d(0, 100);
+
+  while (state.KeepRunning()) {
+    auto observation = d(gen);
+    auto start = std::chrono::high_resolution_clock::now();
+    summary.Observe(observation);
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto elapsed_seconds =
+        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
+    state.SetIterationTime(elapsed_seconds.count());
+  }
+}
+BENCHMARK(BM_Summary_Observe_Common)->Iterations(ITERATIONS);
+
+static void BM_Summary_Collect_Common(benchmark::State& state) {
+  using prometheus::BuildSummary;
+  using prometheus::Registry;
+  using prometheus::Summary;
+
+  const auto number_of_entries = state.range(0);
+
+  Registry registry;
+  auto& summary_family =
+      BuildSummary().Name("benchmark_summary").Help("").Register(registry);
+  auto& summary = summary_family.Add(
+      {}, Summary::Quantiles{
+              {0.5, 0.05}, {0.9, 0.01}, {0.95, 0.005}, {0.99, 0.001}});
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> d(0, 100);
+  for (auto i = 1; i <= number_of_entries; ++i) summary.Observe(d(gen));
+
+  while (state.KeepRunning()) {
+    benchmark::DoNotOptimize(summary.Collect());
+  }
+}
+BENCHMARK(BM_Summary_Collect_Common)->Range(0, ITERATIONS);

--- a/tests/summary_test.cc
+++ b/tests/summary_test.cc
@@ -1,0 +1,99 @@
+#include <gmock/gmock.h>
+
+#include <prometheus/summary.h>
+
+#include <cmath>
+#include <thread>
+
+using namespace testing;
+using namespace prometheus;
+
+class SummaryTest : public Test {};
+
+TEST_F(SummaryTest, initialize_with_zero) {
+  Summary summary{{{}}};
+  auto metric = summary.Collect();
+  ASSERT_TRUE(metric.has_summary());
+  auto s = metric.summary();
+  EXPECT_EQ(s.sample_count(), 0);
+  EXPECT_EQ(s.sample_sum(), 0);
+}
+
+TEST_F(SummaryTest, sample_count) {
+  Summary summary{{{0.5, 0.05}}};
+  summary.Observe(0);
+  summary.Observe(200);
+  auto metric = summary.Collect();
+  ASSERT_TRUE(metric.has_summary());
+  auto s = metric.summary();
+  EXPECT_EQ(s.sample_count(), 2);
+}
+
+TEST_F(SummaryTest, sample_sum) {
+  Summary summary{{{0.5, 0.05}}};
+  summary.Observe(0);
+  summary.Observe(1);
+  summary.Observe(101);
+  auto metric = summary.Collect();
+  ASSERT_TRUE(metric.has_summary());
+  auto s = metric.summary();
+  EXPECT_EQ(s.sample_sum(), 102);
+}
+
+TEST_F(SummaryTest, quantile_size) {
+  Summary summary{{{0.5, 0.05}, {0.90, 0.01}}};
+  auto metric = summary.Collect();
+  ASSERT_TRUE(metric.has_summary());
+  auto s = metric.summary();
+  EXPECT_EQ(s.quantile_size(), 2);
+}
+
+TEST_F(SummaryTest, quantile_bounds) {
+  Summary summary{{{0.5, 0.05}, {0.90, 0.01}, {0.99, 0.001}}};
+  auto metric = summary.Collect();
+  ASSERT_TRUE(metric.has_summary());
+  auto s = metric.summary();
+  ASSERT_EQ(s.quantile_size(), 3);
+  EXPECT_DOUBLE_EQ(s.quantile(0).quantile(), 0.5);
+  EXPECT_DOUBLE_EQ(s.quantile(1).quantile(), 0.9);
+  EXPECT_DOUBLE_EQ(s.quantile(2).quantile(), 0.99);
+}
+
+TEST_F(SummaryTest, quantile_values) {
+  static const int SAMPLES = 1000000;
+
+  Summary summary{{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}}};
+  for (int i = 1; i <= SAMPLES; ++i) summary.Observe(i);
+
+  auto metric = summary.Collect();
+  ASSERT_TRUE(metric.has_summary());
+  auto s = metric.summary();
+  ASSERT_EQ(s.quantile_size(), 3);
+
+  EXPECT_NEAR(s.quantile(0).value(), 0.5 * SAMPLES, 0.05 * SAMPLES);
+  EXPECT_NEAR(s.quantile(1).value(), 0.9 * SAMPLES, 0.01 * SAMPLES);
+  EXPECT_NEAR(s.quantile(2).value(), 0.99 * SAMPLES, 0.001 * SAMPLES);
+}
+
+TEST_F(SummaryTest, max_age) {
+  Summary summary{{{0.99, 0.001}}, std::chrono::seconds(1), 2};
+  summary.Observe(8.0);
+
+  static const auto test_value = [&summary](double ref) {
+    auto metric = summary.Collect();
+    ASSERT_TRUE(metric.has_summary());
+    auto s = metric.summary();
+    ASSERT_EQ(s.quantile_size(), 1);
+
+    if (std::isnan(ref))
+      EXPECT_TRUE(std::isnan(s.quantile(0).value()));
+    else
+      EXPECT_DOUBLE_EQ(s.quantile(0).value(), ref);
+  };
+
+  test_value(8.0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(600));
+  test_value(8.0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(600));
+  test_value(std::numeric_limits<double>::quiet_NaN());
+}


### PR DESCRIPTION
**Issue:** The summary metric type is not implemented, see #4

This implements the summary type. It uses the same implementation as the [java client](https://github.com/prometheus/client_java)

For not it's still work in progess, since I'll want to do some testing in our dev/prod environment and maybe find some performance improvements.