### PR TITLE
fix compile for protobuf 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 bazel-*
+
+/.idea/
+/cmake-build-*/

--- a/include/prometheus/family.h
+++ b/include/prometheus/family.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <numeric>
 #include <string>

--- a/include/prometheus/json_serializer.h
+++ b/include/prometheus/json_serializer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if GOOGLE_PROTOBUF_VERSION >= 3000000
+
 #include <string>
 #include <vector>
 
@@ -15,3 +17,5 @@ class JsonSerializer : public Serializer {
       const std::vector<io::prometheus::client::MetricFamily>& metrics);
 };
 }
+
+#endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,16 @@ add_custom_command(
   COMMENT "Running C++ protocol buffer compiler for metrics"
   VERBATIM)
 
+execute_process(
+  COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+  ARGS --version
+  OUTPUT_VARIABLE PROTOBUF_VERSION_STRING
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+)
+string(REPLACE "libprotoc " "" PROTOBUF_VERSION ${PROTOBUF_VERSION_STRING})
+message(STATUS "Found protobuf version: ${PROTOBUF_VERSION}")
+
 add_library(prometheus-cpp
   check_names.cc
   counter.cc
@@ -25,7 +35,7 @@ add_library(prometheus-cpp
   handler.h
   histogram.cc
   histogram_builder.cc
-  json_serializer.cc
+  $<$<NOT:$<VERSION_LESS:${PROTOBUF_VERSION},3>>:json_serializer.cc>
   protobuf_delimited_serializer.cc
   registry.cc
   text_serializer.cc

--- a/lib/handler.cc
+++ b/lib/handler.cc
@@ -1,5 +1,7 @@
 #include "handler.h"
-#include "prometheus/json_serializer.h"
+#if GOOGLE_PROTOBUF_VERSION >= 3000000
+#  include "prometheus/json_serializer.h"
+#endif
 #include "prometheus/protobuf_delimited_serializer.h"
 #include "prometheus/serializer.h"
 #include "prometheus/text_serializer.h"
@@ -62,9 +64,11 @@ bool MetricsHandler::handleGet(CivetServer* server,
         "application/vnd.google.protobuf; "
         "proto=io.prometheus.client.MetricFamily; "
         "encoding=delimited";
+#if GOOGLE_PROTOBUF_VERSION >= 3000000
   } else if (accepted_encoding.find("application/json") != std::string::npos) {
     serializer.reset(new JsonSerializer());
     content_type = "application/json";
+#endif
   } else {
     serializer.reset(new TextSerializer());
     content_type = "text/plain";

--- a/lib/text_serializer.cc
+++ b/lib/text_serializer.cc
@@ -1,6 +1,7 @@
 #include "prometheus/text_serializer.h"
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <sstream>
 
 namespace prometheus {


### PR DESCRIPTION
**Issue:** Due to dependency problems on certain systems using protobuf 3.x is not an option.

This fixes any compile issues when building with protobuf 2.x.