### PR TITLE
Fix link issue with ZLib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 find_package(GoogleBenchmark)
 find_package(Protobuf REQUIRED)
+find_package(ZLIB REQUIRED)
 find_package(Telegraf)
 
 # suppress warnings

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(prometheus-cpp
 )
 
 # TODO(gj) make all PRIVATE
-target_link_libraries(prometheus-cpp PUBLIC ${PROTOBUF_LIBRARIES})
+target_link_libraries(prometheus-cpp PUBLIC ${PROTOBUF_LIBRARIES} ${ZLIB_LIBRARIES} )
 target_include_directories(prometheus-cpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 target_include_directories(prometheus-cpp PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 target_include_directories(prometheus-cpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)


### PR DESCRIPTION
This is small fix for issue I had when compiling (in my slightly particular environment): linking with old system ZLib instead of the one I wanted.

libprotobuf.so: undefined reference to `deflate'
libprotobuf.so: undefined reference to `deflateEnd'
libprotobuf.so: undefined reference to `inflate'
libprotobuf.so: undefined reference to `inflateInit2_'
libprotobuf.so: undefined reference to `inflateEnd'
