### PR TITLE
Fix implicit instantiation of undefined template

### DIFF
--- a/include/prometheus/summary.h
+++ b/include/prometheus/summary.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <list>


### PR DESCRIPTION
This patch fix error: implicit instantiation of undefined template
`std::__1::array<double, 500>` when it is compiled using Clang on osx.