### PR TITLE
Fix compilation on ubuntu 16.04

### DIFF
--- a/lib/text_serializer.cc
+++ b/lib/text_serializer.cc
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <iostream>
 #include <sstream>
+#include <limits>
 
 namespace prometheus {
 


### PR DESCRIPTION
Compiler is: "gcc (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609"
The import of `<limits>` is required to use `std::numeric_limits`