### PR TITLE
Add cmake option to build shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bazel-*
+build*
+_build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ find_package(Protobuf REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Telegraf)
 
+
+if(DEFINED MAKE_SHARED AND MAKE_SHARED EQUAL 1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+endif()
+
 # suppress warnings
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ target_compile_definitions(civetweb PRIVATE
   NO_FILES
 )
 
+
 target_include_directories(civetweb PUBLIC
   ${CIVETWEB_INCLUDE_DIR}
 )

--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ mkdir _build
 cd _build
 
 # run cmake
+# to build static library
 cmake ..
+
+# to build dynamic library
+cmake .. -DMAKE_SHARED=1
 
 # build
 make -j 4

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,7 +14,10 @@ add_custom_command(
   COMMENT "Running C++ protocol buffer compiler for metrics"
   VERBATIM)
 
-add_library(prometheus-cpp
+include_directories("${PROJECT_SOURCE_DIR}/3rdparty/civetweb/include")
+include_directories("${METRICS_BINARY_DIR}")
+
+add_library(prometheus-cpp-object OBJECT
   check_names.cc
   counter.cc
   counter_builder.cc
@@ -31,16 +34,30 @@ add_library(prometheus-cpp
   summary_builder.cc
   text_serializer.cc
 
-  # civetweb
-
-  $<TARGET_OBJECTS:civetweb>
-
   # Metrics Protocol
 
   ${METRICS_SOURCE_FILE}
   ${METRICS_BINARY_DIR}/metrics.pb.cc
   ${METRICS_BINARY_DIR}/metrics.pb.h
-)
+)  
+
+
+if(DEFINED MAKE_SHARED AND MAKE_SHARED EQUAL 1)
+  add_library(prometheus-cpp SHARED
+    $<TARGET_OBJECTS:prometheus-cpp-object>
+
+    # civetweb
+    $<TARGET_OBJECTS:civetweb>
+  )
+
+else()
+  add_library(prometheus-cpp
+    $<TARGET_OBJECTS:prometheus-cpp-object>
+
+    # civetweb
+    $<TARGET_OBJECTS:civetweb>
+  )
+endif()
 
 # TODO(gj) make all PRIVATE
 target_link_libraries(prometheus-cpp PUBLIC ${PROTOBUF_LIBRARIES} ${ZLIB_LIBRARIES} )


### PR DESCRIPTION
This will allow shared library projects to integrate with prometheus.
Changes:
- Add MAKE_SHARED variable to build shared library. By default, it will build static.
- If MAKE_SHARED=1 then everything will build using "-fPIC"
