### PR TITLE
Fix uninitialized buffer causing compiler warnings

### DIFF
--- a/lib/summary.cc
+++ b/lib/summary.cc
@@ -1,7 +1,7 @@
 #include "prometheus/summary.h"
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 
 namespace prometheus {
 
@@ -17,7 +17,7 @@ CKMSQuantiles::Item::Item(double value, int lower_delta, int delta)
     : value(value), g(lower_delta), delta(delta) {}
 
 CKMSQuantiles::CKMSQuantiles(const std::vector<Quantile>& quantiles)
-    : quantiles_(quantiles), count_(0), buffer_count_(0) {}
+    : quantiles_(quantiles), count_(0), buffer_{}, buffer_count_(0) {}
 
 void CKMSQuantiles::insert(double value) {
   buffer_[buffer_count_] = value;


### PR DESCRIPTION
This change fixes a gcc warning about an unitialized std::array
in the summary implementation. Fixes #102.