### PR TITLE
Fix compile error text_serializer.cc:131:18: error: 'numeric_limits' …

### DIFF
--- a/lib/text_serializer.cc
+++ b/lib/text_serializer.cc
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <iostream>
 #include <sstream>
+#include <limits>
 
 namespace prometheus {
 


### PR DESCRIPTION
…is not a member of 'std'