### PR TITLE
Fix GCC 7 compile error

### DIFF
--- a/include/prometheus/summary.h
+++ b/include/prometheus/summary.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <list>
 #include <mutex>
 #include <vector>


### PR DESCRIPTION
This change fixes #107 by adding a missing include causing
compile erros on GCC 7. Thanks to Romain Sertelon for reporting this.