### PR TITLE
Extract the `prometheus-core` library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,14 +1,11 @@
 cc_library(
-    name = "prometheus_cpp",
+    name = "prometheus_core",
     srcs = [
         "lib/check_names.cc",
         "lib/counter.cc",
         "lib/counter_builder.cc",
-        "lib/exposer.cc",
         "lib/gauge.cc",
         "lib/gauge_builder.cc",
-        "lib/handler.cc",
-        "lib/handler.h",
         "lib/histogram.cc",
         "lib/histogram_builder.cc",
         "lib/registry.cc",
@@ -22,7 +19,20 @@ cc_library(
     linkstatic = 1,
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "prometheus_cpp",
+    srcs = [
+        "lib/exposer.cc",
+        "lib/handler.cc",
+        "lib/handler.h",
+    ],
+    linkstatic = 1,
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
     deps = [
+        ":prometheus_core",
         "@civetweb//:civetweb",
     ],
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,21 +1,25 @@
-add_library(prometheus-cpp
+add_library(prometheus-core OBJECT
   check_names.cc
   counter.cc
   counter_builder.cc
-  exposer.cc
   gauge.cc
   gauge_builder.cc
-  handler.cc
-  handler.h
   histogram.cc
   histogram_builder.cc
   registry.cc
   summary.cc
   summary_builder.cc
   text_serializer.cc
+)
+
+add_library(prometheus-cpp
+  exposer.cc
+  handler.cc
+  handler.h
 
   # civetweb
 
+  $<TARGET_OBJECTS:prometheus-core>
   $<TARGET_OBJECTS:civetweb>
 )
 
@@ -24,6 +28,7 @@ if(UNIX AND NOT APPLE)
   target_link_libraries(prometheus-cpp PRIVATE rt)
 endif()
 
+target_include_directories(prometheus-core PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 target_include_directories(prometheus-cpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 target_include_directories(prometheus-cpp PRIVATE ${CIVETWEB_INCLUDE_DIR})
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -109,35 +109,38 @@ cc_library(
 """
 
 def load_civetweb():
-    native.new_http_archive(
-        name = "civetweb",
-        strip_prefix = "civetweb-1.9.1",
-        sha256 = "880d741724fd8de0ebc77bc5d98fa673ba44423dc4918361c3cd5cf80955e36d",
-        urls = [
-           "https://github.com/civetweb/civetweb/archive/v1.9.1.tar.gz",
-       ],
-       build_file_content = _CIVETWEB_BUILD_FILE,
-    )
+    if "civetweb" not in native.existing_rules():
+        native.new_http_archive(
+            name = "civetweb",
+            strip_prefix = "civetweb-1.9.1",
+            sha256 = "880d741724fd8de0ebc77bc5d98fa673ba44423dc4918361c3cd5cf80955e36d",
+            urls = [
+            "https://github.com/civetweb/civetweb/archive/v1.9.1.tar.gz",
+        ],
+        build_file_content = _CIVETWEB_BUILD_FILE,
+        )
 
 def load_com_google_googletest():
-    native.http_archive(
-        name = "com_google_googletest",
-        strip_prefix = "googletest-master",
-        urls = [
-            "https://github.com/google/googletest/archive/master.zip",
-        ],
-    )
+    if "com_google_googletest" not in native.existing_rules():
+        native.http_archive(
+            name = "com_google_googletest",
+            strip_prefix = "googletest-master",
+            urls = [
+                "https://github.com/google/googletest/archive/master.zip",
+            ],
+        )
 
 def load_com_google_googlebenchmark():
-    native.new_http_archive(
-        name = "com_google_googlebenchmark",
-        sha256 = "3dcc90c158838e2ac4a7ad06af9e28eb5877cf28252a81e55eb3c836757d3070",
-        strip_prefix = "benchmark-1.2.0",
-        urls = [
-            "https://github.com/google/benchmark/archive/v1.2.0.tar.gz",
-        ],
-        build_file_content = _GOOGLEBENCHEMARK_BUILD_FILE,
-    )
+    if "com_google_googlebenchmark" not in native.existing_rules():
+        native.new_http_archive(
+            name = "com_google_googlebenchmark",
+            sha256 = "3dcc90c158838e2ac4a7ad06af9e28eb5877cf28252a81e55eb3c836757d3070",
+            strip_prefix = "benchmark-1.2.0",
+            urls = [
+                "https://github.com/google/benchmark/archive/v1.2.0.tar.gz",
+            ],
+            build_file_content = _GOOGLEBENCHEMARK_BUILD_FILE,
+        )
 
 def prometheus_cpp_repositories():
     load_civetweb()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -13,7 +13,7 @@ cc_test(
     copts = ["-Iexternal/googletest/include"],
     linkstatic = 1,
     deps = [
-        "//:prometheus_cpp",
+        "//:prometheus_core",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,9 +13,11 @@ add_executable(prometheus_test
   mock_metric.h
   registry_test.cc
   summary_test.cc
+
+  $<TARGET_OBJECTS:prometheus-core>
 )
 
-target_link_libraries(prometheus_test PRIVATE prometheus-cpp)
+target_include_directories(prometheus_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 target_include_directories(prometheus_test PRIVATE ${PROJECT_SOURCE_DIR}) # fixme
 
 target_link_libraries(prometheus_test PRIVATE gmock_main)

--- a/tests/benchmark/BUILD
+++ b/tests/benchmark/BUILD
@@ -12,7 +12,7 @@ cc_binary(
     ],
     linkstatic = 1,
     deps = [
-        "//:prometheus_cpp",
+        "//:prometheus_core",
         "@com_google_googlebenchmark//:googlebenchmark",
     ],
 )

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -7,9 +7,11 @@ add_executable(benchmarks
   histogram_bench.cc
   registry_bench.cc
   summary_bench.cc
+
+  $<TARGET_OBJECTS:prometheus-core>
 )
 
-target_link_libraries(benchmarks PRIVATE prometheus-cpp)
+target_include_directories(benchmarks PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 target_include_directories(benchmarks PRIVATE ${PROJECT_SOURCE_DIR}) # fixme
 
 target_link_libraries(benchmarks PRIVATE Google::Benchmark)


### PR DESCRIPTION
related to #101, then we can use `prometheus-core` library without `civetweb`, and we may add #23 or other features later.