### PR TITLE
added build options BUILD_TESTING and BUILD_CIVETWEB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ if(NOT DEFINED CMAKE_CXX_STANDARD AND UNIX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
-OPTION(BUILD_CIVETWEB "Embed Civet webserver in prometheus" ON)
-ENABLE_TESTING()
-INCLUDE(CTest)
+option(BUILD_CIVETWEB "Embed Civet webserver in prometheus" ON)
+enable_testing()
+include(CTest)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ if(APPLE)
 endif()
 
 if (BUILD_CIVETWEB)
-	find_package(ZLIB REQUIRED)
 	# civetweb
 	set(CIVETWEB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/3rdparty/civetweb/include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 if(NOT DEFINED CMAKE_CXX_STANDARD AND UNIX)
-	set(CMAKE_CXX_STANDARD 11)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 OPTION(BUILD_CIVETWEB "Embed Civet webserver in prometheus" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,76 +1,80 @@
 cmake_minimum_required(VERSION 2.8.12.2 FATAL_ERROR)
-
 project(prometheus-cpp)
-enable_testing()
-include(GNUInstallDirs)
 
+enable_testing()
+
+include(GNUInstallDirs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 if(NOT DEFINED CMAKE_CXX_STANDARD AND UNIX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+	set(CMAKE_CXX_STANDARD 11)
 endif()
+
+OPTION(BUILD_CIVETWEB "Embed Civet webserver in prometheus" ON)
+ENABLE_TESTING()
+INCLUDE(CTest)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)
 
-find_package(GoogleBenchmark)
-find_package(ZLIB REQUIRED)
-find_package(Telegraf)
-
 # suppress warnings
-
 if(APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 endif()
 
-# civetweb
+if (BUILD_CIVETWEB)
+	find_package(ZLIB REQUIRED)
+	# civetweb
+	set(CIVETWEB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/3rdparty/civetweb/include)
 
-set(CIVETWEB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/3rdparty/civetweb/include)
+	add_library(civetweb OBJECT
+		3rdparty/civetweb/include/CivetServer.h
+		3rdparty/civetweb/include/civetweb.h
+		3rdparty/civetweb/src/CivetServer.cpp
+		3rdparty/civetweb/src/civetweb.c
+		3rdparty/civetweb/src/handle_form.inl
+		3rdparty/civetweb/src/md5.inl
+	)
 
-add_library(civetweb OBJECT
-  3rdparty/civetweb/include/CivetServer.h
-  3rdparty/civetweb/include/civetweb.h
-  3rdparty/civetweb/src/CivetServer.cpp
-  3rdparty/civetweb/src/civetweb.c
-  3rdparty/civetweb/src/handle_form.inl
-  3rdparty/civetweb/src/md5.inl
-)
+	target_compile_definitions(civetweb PRIVATE
+		USE_IPV6
+		NDEBUG
+		NO_CGI
+		NO_CACHING
+		NO_SSL
+		NO_FILES
+	)
 
-target_compile_definitions(civetweb PRIVATE
-  USE_IPV6
-  NDEBUG
-  NO_CGI
-  NO_CACHING
-  NO_SSL
-  NO_FILES
-)
-
-target_include_directories(civetweb PUBLIC
-  ${CIVETWEB_INCLUDE_DIR}
-)
-
-# google mock
-
-add_library(gmock_main STATIC EXCLUDE_FROM_ALL
-  3rdparty/googletest/googletest/src/gtest-all.cc
-  3rdparty/googletest/googlemock/src/gmock-all.cc
-  3rdparty/googletest/googlemock/src/gmock_main.cc
-)
-
-target_include_directories(gmock_main
-  PUBLIC
-    3rdparty/googletest/googletest/include
-    3rdparty/googletest/googlemock/include
-  PRIVATE
-    3rdparty/googletest/googletest
-    3rdparty/googletest/googlemock
-)
-
-target_link_libraries(gmock_main PRIVATE
-  ${CMAKE_THREAD_LIBS_INIT}
-)
+	target_include_directories(civetweb PUBLIC
+		${CIVETWEB_INCLUDE_DIR}
+	)
+endif()
 
 # prometheus-cpp
-
 add_subdirectory(lib)
-add_subdirectory(tests)
+
+if (BUILD_TESTING)
+	find_package(GoogleBenchmark)
+	find_package(Telegraf)
+	# google mock
+	add_library(gmock_main STATIC EXCLUDE_FROM_ALL
+		3rdparty/googletest/googletest/src/gtest-all.cc
+		3rdparty/googletest/googlemock/src/gmock-all.cc
+		3rdparty/googletest/googlemock/src/gmock_main.cc
+	)
+
+	target_include_directories(gmock_main
+		PUBLIC
+			3rdparty/googletest/googletest/include
+			3rdparty/googletest/googlemock/include
+		PRIVATE
+			3rdparty/googletest/googletest
+			3rdparty/googletest/googlemock
+	)
+
+	target_link_libraries(gmock_main PRIVATE
+		${CMAKE_THREAD_LIBS_INIT}
+	)
+	add_subdirectory(tests)
+endif()
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,9 +24,6 @@ add_library(prometheus-cpp
 )
 
 target_link_libraries(prometheus-cpp PRIVATE ${CMAKE_THREAD_LIBS_INIT})
-if (BUILD_CIVETWEB)
-	target_link_libraries(prometheus-cpp PRIVATE ${ZLIB_LIBRARIES})
-endif()
 if(UNIX AND NOT APPLE)
   target_link_libraries(prometheus-cpp PRIVATE rt)
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,25 +1,32 @@
-add_library(prometheus-cpp
+set(PROMETHEUS_SOURCES 
   check_names.cc
   counter.cc
   counter_builder.cc
-  exposer.cc
   gauge.cc
   gauge_builder.cc
-  handler.cc
-  handler.h
   histogram.cc
   histogram_builder.cc
   registry.cc
   summary.cc
   summary_builder.cc
   text_serializer.cc
+	)
+if (BUILD_CIVETWEB)
+	set(PROMETHEUS_SOURCES ${PROMETHEUS_SOURCES} 
+		exposer.cc
+		handler.cc
+		$<TARGET_OBJECTS:civetweb>
+		)
+endif()
 
-  # civetweb
-
-  $<TARGET_OBJECTS:civetweb>
+add_library(prometheus-cpp
+	${PROMETHEUS_SOURCES}
 )
 
-target_link_libraries(prometheus-cpp PRIVATE ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+target_link_libraries(prometheus-cpp PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+if (BUILD_CIVETWEB)
+	target_link_libraries(prometheus-cpp PRIVATE ${ZLIB_LIBRARIES})
+endif()
 if(UNIX AND NOT APPLE)
   target_link_libraries(prometheus-cpp PRIVATE rt)
 endif()


### PR DESCRIPTION
These options are to build the testing and to embed the webserver in prometheus-cpp. This way, the project can be used in a more flexible way. The options defaults to on.

Only adjusted the CMake file so it works for us.

Related to https://github.com/jupp0r/prometheus-cpp/pull/112 .