### PR TITLE
Add push library

### DIFF
--- a/core/include/prometheus/serializer.h
+++ b/core/include/prometheus/serializer.h
@@ -11,6 +11,6 @@ namespace prometheus {
 class Serializer {
  public:
   virtual ~Serializer() = default;
-  virtual std::string Serialize(const std::vector<MetricFamily>&) = 0;
+  virtual std::string Serialize(const std::vector<MetricFamily>&) const = 0;
 };
 }  // namespace prometheus

--- a/core/include/prometheus/text_serializer.h
+++ b/core/include/prometheus/text_serializer.h
@@ -10,6 +10,7 @@ namespace prometheus {
 
 class TextSerializer : public Serializer {
  public:
-  std::string Serialize(const std::vector<MetricFamily>& metrics);
+  std::string Serialize(
+      const std::vector<MetricFamily>& metrics) const override;
 };
 }

--- a/core/src/text_serializer.cc
+++ b/core/src/text_serializer.cc
@@ -184,7 +184,7 @@ void SerializeFamily(std::ostream& out, const MetricFamily& family) {
 }
 
 std::string TextSerializer::Serialize(
-    const std::vector<MetricFamily>& metrics) {
+    const std::vector<MetricFamily>& metrics) const {
   std::ostringstream ss;
   for (auto& family : metrics) {
     SerializeFamily(ss, family);

--- a/push/BUILD.bazel
+++ b/push/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_library(
+    name = "push",
+    srcs = glob([
+        "src/**/*.cc",
+        "src/**/*.h",
+    ]),
+    hdrs = glob(
+        ["include/**/*.h"],
+    ),
+    linkstatic = 1,
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core",
+        "@com_github_whoshuu_cpr//:cpr",
+    ],
+)

--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory>
+#include <sstream>
+
+#include <cpr/cpr.h>
+
+#include "histogram.h"
+#include "registry.h"
+
+namespace prometheus {
+
+class Gateway {
+ public:
+  typedef std::map<std::string, std::string> labels_t;
+
+  explicit Gateway(const std::string& uri, const std::string jobname,
+                   const labels_t* labels = nullptr,
+                   const std::string username = "",
+                   const std::string password = "");
+  ~Gateway() {}
+
+  void RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
+                           const labels_t* labels = nullptr);
+
+  static const labels_t instance_label(void);
+
+  // Push metrics to the given pushgateway.
+  int Push(void) { return push(false); }
+
+  std::future<int> AsyncPush(void) { return async_push(false); }
+
+  // PushAdd metrics to the given pushgateway.
+  int PushAdd(void) { return push(true); }
+
+  std::future<int> AsyncPushAdd(void) { return async_push(true); }
+
+  // Delete metrics from the given pushgateway.
+  int Delete(void);
+
+  // Delete metrics from the given pushgateway.
+  cpr::AsyncResponse AsyncDelete(void);
+
+ private:
+  std::vector<std::pair<std::weak_ptr<Collectable>, std::string>> collectables_;
+  std::string uri_;
+  std::string jobname_;
+  std::string labels_;
+  std::string username_;
+  std::string password_;
+
+  std::stringstream job_uri(void) const;
+
+  int push(bool replacing);
+
+  std::future<int> async_push(bool replacing);
+};
+
+}  // namespace prometheus

--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -1,59 +1,62 @@
 #pragma once
 
+#include <future>
+#include <map>
 #include <memory>
 #include <sstream>
 
 #include <cpr/cpr.h>
 
-#include "histogram.h"
-#include "registry.h"
+#include "prometheus/histogram.h"
+#include "prometheus/registry.h"
 
 namespace prometheus {
 
 class Gateway {
  public:
-  typedef std::map<std::string, std::string> labels_t;
+  using Labels = std::map<std::string, std::string>;
 
-  explicit Gateway(const std::string& uri, const std::string jobname,
-                   const labels_t* labels = nullptr,
-                   const std::string username = "",
-                   const std::string password = "");
-  ~Gateway() {}
+  Gateway(const std::string& uri, const std::string jobname,
+          const Labels& labels = {}, const std::string username = {},
+          const std::string password = {});
 
   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
-                           const labels_t* labels = nullptr);
+                           const Labels* labels = nullptr);
 
-  static const labels_t instance_label(void);
+  static const Labels GetInstanceLabel(std::string hostname);
 
   // Push metrics to the given pushgateway.
-  int Push(void) { return push(false); }
+  int Push() { return push(PushMode::Replace); }
 
-  std::future<int> AsyncPush(void) { return async_push(false); }
+  std::future<int> AsyncPush() { return async_push(PushMode::Replace); }
 
   // PushAdd metrics to the given pushgateway.
-  int PushAdd(void) { return push(true); }
+  int PushAdd() { return push(PushMode::Add); }
 
-  std::future<int> AsyncPushAdd(void) { return async_push(true); }
-
-  // Delete metrics from the given pushgateway.
-  int Delete(void);
+  std::future<int> AsyncPushAdd() { return async_push(PushMode::Add); }
 
   // Delete metrics from the given pushgateway.
-  cpr::AsyncResponse AsyncDelete(void);
+  int Delete();
+
+  // Delete metrics from the given pushgateway.
+  cpr::AsyncResponse AsyncDelete();
 
  private:
-  std::vector<std::pair<std::weak_ptr<Collectable>, std::string>> collectables_;
-  std::string uri_;
-  std::string jobname_;
+  std::string jobUri_;
   std::string labels_;
   std::string username_;
   std::string password_;
 
-  std::stringstream job_uri(void) const;
+  std::vector<std::pair<std::weak_ptr<Collectable>, std::string>> collectables_;
 
-  int push(bool replacing);
+  enum class PushMode {
+    Add,
+    Replace,
+  };
 
-  std::future<int> async_push(bool replacing);
+  int push(PushMode mode);
+
+  std::future<int> async_push(PushMode mode);
 };
 
 }  // namespace prometheus

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -1,0 +1,149 @@
+#include <sys/param.h>
+#include <unistd.h>
+
+#include "prometheus/client_metric.h"
+#include "prometheus/gateway.h"
+#include "prometheus/serializer.h"
+#include "prometheus/text_serializer.h"
+
+namespace prometheus {
+
+const char* CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+Gateway::Gateway(const std::string& uri, const std::string jobname,
+                 const labels_t* labels, const std::string username,
+                 const std::string password)
+    : uri_(uri), jobname_(jobname), username_(username), password_(password) {
+  if (labels) {
+    std::stringstream ss;
+
+    if (labels) {
+      for (auto& label : *labels) {
+        ss << "/" << label.first << "/" << label.second;
+      }
+    }
+
+    labels_ = ss.str();
+  }
+}
+
+const Gateway::labels_t Gateway::instance_label(void) {
+  char hostname[MAXHOSTNAMELEN] = {0};
+
+  if (gethostname(hostname, MAXHOSTNAMELEN - 1)) {
+    hostname[0] = 0;
+  }
+
+  return Gateway::labels_t{{"instance", hostname}};
+}
+
+void Gateway::RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
+                                  const labels_t* labels) {
+  std::stringstream ss;
+
+  if (labels) {
+    for (auto& label : *labels) {
+      ss << "/" << label.first << "/" << label.second;
+    }
+  }
+
+  collectables_.push_back(std::make_pair(collectable, ss.str()));
+}
+
+std::stringstream Gateway::job_uri(void) const {
+  std::stringstream ss;
+
+  ss << uri_ << "/metrics/job/" << jobname_;
+
+  return ss;
+}
+
+int Gateway::push(bool replacing) {
+  for (auto& wcollectable : collectables_) {
+    auto collectable = wcollectable.first.lock();
+    if (!collectable) {
+      continue;
+    }
+
+    auto metrics = std::vector<MetricFamily>{};
+
+    for (auto metric : collectable->Collect()) {
+      metrics.push_back(metric);
+    }
+
+    auto uri = job_uri() << labels_ << wcollectable.second;
+
+    auto serializer = std::unique_ptr<Serializer>{new TextSerializer()};
+
+    auto body = serializer->Serialize(metrics);
+
+    auto res = replacing
+                   ? cpr::Post(cpr::Url{uri.str()},
+                               cpr::Header{{"Content-Type", CONTENT_TYPE}},
+                               cpr::Body{body})
+                   : cpr::Put(cpr::Url{uri.str()},
+                              cpr::Header{{"Content-Type", CONTENT_TYPE}},
+                              cpr::Body{body});
+
+    if (res.status_code >= 400) {
+      return res.status_code;
+    }
+  }
+
+  return 200;
+}
+
+std::future<int> Gateway::async_push(bool replacing) {
+  std::vector<cpr::AsyncResponse> pushes;
+
+  for (auto& wcollectable : collectables_) {
+    auto collectable = wcollectable.first.lock();
+    if (!collectable) {
+      continue;
+    }
+
+    auto metrics = std::vector<MetricFamily>{};
+
+    for (auto metric : collectable->Collect()) {
+      metrics.push_back(metric);
+    }
+
+    auto uri = job_uri() << labels_ << wcollectable.second;
+
+    auto serializer = std::unique_ptr<Serializer>{new TextSerializer()};
+
+    auto body = serializer->Serialize(metrics);
+
+    pushes.push_back(
+        replacing ? cpr::PostAsync(cpr::Url{uri.str()},
+                                   cpr::Header{{"Content-Type", CONTENT_TYPE}},
+                                   cpr::Body{body})
+                  : cpr::PutAsync(cpr::Url{uri.str()},
+                                  cpr::Header{{"Content-Type", CONTENT_TYPE}},
+                                  cpr::Body{body}));
+  }
+
+  return std::async(std::launch::async, [&] {
+    for (auto& push : pushes) {
+      auto res = push.get();
+
+      if (res.status_code > 400) {
+        return res.status_code;
+      }
+    }
+
+    return 200;
+  });
+}
+
+int Gateway::Delete(void) {
+  auto res = cpr::Delete(cpr::Url{cpr::Url{job_uri().str()}});
+
+  return res.status_code;
+}
+
+cpr::AsyncResponse Gateway::AsyncDelete(void) {
+  return cpr::DeleteAsync(cpr::Url{job_uri().str()});
+}
+
+}  // namespace prometheus

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -44,6 +44,8 @@ void Gateway::RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
 }
 
 int Gateway::push(PushMode mode) {
+  const auto serializer = TextSerializer{};
+
   for (auto& wcollectable : collectables_) {
     auto collectable = wcollectable.first.lock();
     if (!collectable) {
@@ -59,9 +61,7 @@ int Gateway::push(PushMode mode) {
     auto uri = std::stringstream{};
     uri << jobUri_ << labels_ << wcollectable.second;
 
-    auto serializer = std::unique_ptr<Serializer>{new TextSerializer()};
-
-    auto body = serializer->Serialize(metrics);
+    auto body = serializer.Serialize(metrics);
 
     cpr::Session session;
 
@@ -84,6 +84,7 @@ int Gateway::push(PushMode mode) {
 }
 
 std::future<int> Gateway::async_push(PushMode mode) {
+  const auto serializer = TextSerializer{};
   std::vector<cpr::AsyncResponse> futures;
 
   for (auto& wcollectable : collectables_) {
@@ -101,9 +102,7 @@ std::future<int> Gateway::async_push(PushMode mode) {
     auto uri = std::stringstream{};
     uri << jobUri_ << labels_ << wcollectable.second;
 
-    auto serializer = std::unique_ptr<Serializer>{new TextSerializer()};
-
-    auto body = serializer->Serialize(metrics);
+    auto body = serializer.Serialize(metrics);
 
     cpr::Session session;
 

--- a/push/tests/integration/BUILD.bazel
+++ b/push/tests/integration/BUILD.bazel
@@ -1,0 +1,5 @@
+cc_binary(
+    name = "sample_client",
+    srcs = ["sample_client.cc"],
+    deps = ["//push"],
+)

--- a/push/tests/integration/push_client.cc
+++ b/push/tests/integration/push_client.cc
@@ -1,0 +1,53 @@
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <prometheus/exposer.h>
+#include <prometheus/gateway.h>
+#include <prometheus/registry.h>
+
+int main(int argc, char** argv) {
+  using namespace prometheus;
+
+  // create an http server running on port 8080
+  Exposer exposer{"127.0.0.1:8080"};
+
+  // create a push gateway
+  auto labels = Gateway::instance_label();
+
+  Gateway gateway{"127.0.0.1:9091", "sample_server", &labels};
+
+  // create a metrics registry with component=main labels applied to all its
+  // metrics
+  auto registry = std::make_shared<Registry>();
+
+  // add a new counter family to the registry (families combine values with the
+  // same name, but distinct label dimenstions)
+  auto& counter_family = BuildCounter()
+                             .Name("time_running_seconds")
+                             .Help("How many seconds is this server running?")
+                             .Labels({{"label", "value"}})
+                             .Register(*registry);
+
+  // add a counter to the metric family
+  auto& second_counter = counter_family.Add(
+      {{"another_label", "value"}, {"yet_another_label", "value"}});
+
+  // ask the exposer to scrape the registry on incoming scrapes
+  exposer.RegisterCollectable(registry);
+
+  // ask the pusher to push the metrics to the pushgateway
+  gateway.RegisterCollectable(registry);
+
+  for (;;) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    // increment the counter by one (second)
+    second_counter.Increment();
+
+    // push metrics
+    gateway.Push();
+  }
+  return 0;
+}

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -95,6 +95,27 @@ cc_library(
 )
 """
 
+_CPR_BUILD_FILE = """
+licenses(["notice"])  # Apache-2.0 license
+
+cc_library(
+    name = "cpr",
+    srcs = glob([
+        "cpr/*.cpp",
+    ]),
+    hdrs = glob([
+        "include/cpr/*.h",
+    ]),
+    includes = [
+        "include",
+    ],
+    linkopts = [
+        "-lcurl",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
 def load_civetweb():
     native.new_http_archive(
         name = "civetweb",
@@ -125,7 +146,19 @@ def load_com_github_google_benchmark():
         ],
     )
 
+def load_com_github_whoshuu_cpr():
+    native.new_http_archive(
+        name = "com_github_whoshuu_cpr",
+        sha256 = "82597627e8b2aef1f0482631c9b11595c63a7565bb462a5995d126da4419ac99",
+        strip_prefix = "cpr-1.3.0",
+        urls = [
+            "https://github.com/whoshuu/cpr/archive/1.3.0.tar.gz",
+        ],
+        build_file_content = _CPR_BUILD_FILE,
+    )
+
 def prometheus_cpp_repositories():
     load_civetweb()
     load_com_google_googletest()
     load_com_github_google_benchmark()
+    load_com_github_whoshuu_cpr()


### PR DESCRIPTION
This is based on #113 (and on #123). I hope I addressed all open issues. I moved the hostname retrieval outside of the library because it is platform dependent code and one might want to customize it. On Windows one also has to do the "Winsock init dance".

What I'm unsure about is the selection of cpr as a http library. It's not available in Ubuntu or Homebrew. Maybe adding it as submodule like it was done for civetweb is the way to go. But CMake support will follow in another PR.