### PR TITLE
Fix summary text format according to specs.

### DIFF
--- a/core/src/text_serializer.cc
+++ b/core/src/text_serializer.cc
@@ -101,7 +101,7 @@ void SerializeSummary(std::ostream& out, const MetricFamily& family,
   WriteTail(out, metric);
 
   for (auto& q : sum.quantile) {
-    WriteHead(out, family, metric, "_quantile", "quantile",
+    WriteHead(out, family, metric, "", "quantile",
               ToString(q.quantile));
     out << ToString(q.value);
     WriteTail(out, metric);


### PR DESCRIPTION
According to the [Prometheus text exposition format][1] each quantile
named x is given as a separate line with the same name x and a label
{quantile="y"}.
But current Prometheus C++ implementation serializes summary named x
with a name x + "_quantile" for each quantile. This is off spec.

[1]: https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md