### PR TITLE
Remove .bazelignore to prevent Bazel 0.17.1 from crashing

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,0 @@
-3rdparty


### PR DESCRIPTION
Issue: bazelbuild/bazel#6149