### PR TITLE
Bazel: ignore 3rdparty directory

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+3rdparty


### PR DESCRIPTION
Locally Bazel 0.17.2 seems to work. Let's see if Travis agrees.