### PR TITLE
Allow people who have well defined CXXFLAG with -std=gnu++17 to use it safely if they want to

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,19 @@ include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS Off)
-
 option(ENABLE_PULL "Build prometheus-cpp pull library" ON)
 option(ENABLE_PUSH "Build prometheus-cpp push library" ON)
 option(ENABLE_COMPRESSION "Enable gzip compression" ON)
 option(ENABLE_TESTING "Build tests" ON)
 option(USE_THIRDPARTY_LIBRARIES "Use 3rdParty submodules" ON)
+
+option(OVERRIDE_CXX_STANDARD_FLAGS "Force building with -std=c++11 even if the CXXLFAGS are configured differently" ON)
+
+if (OVERRIDE_CXX_STANDARD_FLAGS)
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_EXTENSIONS Off)
+endif()
+
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)


### PR DESCRIPTION
Hi,

This fixes a mistake that unfortunately I see far too often in small cmake projects: -std=c++11 is being artibrarily forced to some values

Normally big organisations like mine do rebuild everything themselves and make sure that they control the C++ standard flags used all over all their compilation units. Indeed while quite close, C++11, C++14, C++17 and C++20 are both binary and source incompatible with each other. Compiling prometheus-cpp with C++11 while we actually use C++17 in all our own software otherwise may work, but is a good way to look for tricky problems to investigate in case things like STL containers passed from one C++17 binary to a C++11 binary are actually binary incompatible. This effect is even more true in presence of LTO builds (which we do as well) where it's very important that all compilation units have consistant flags with each other. So for these organisations who fully control the standard, let them use the good defaults already set in the environments CXXFLAGS.

Cheers,
Romain