### PR TITLE
Make labels orderable

### DIFF
--- a/core/include/prometheus/client_metric.h
+++ b/core/include/prometheus/client_metric.h
@@ -17,6 +17,10 @@ struct ClientMetric {
     std::string name;
     std::string value;
 
+    bool operator<(const Label& rhs) const {
+      return std::tie(name, value) < std::tie(rhs.name, rhs.value);
+    }
+
     bool operator==(const Label& rhs) const {
       return std::tie(name, value) == std::tie(rhs.name, rhs.value);
     }


### PR DESCRIPTION
This enables e.g. sorting labels in place or using them as map keys.