### PR TITLE
Breaking Change: Use recommended metric naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
   // add a new counter family to the registry (families combine values with the
   // same name, but distinct label dimensions)
   auto& counter_family = BuildCounter()
-                             .Name("time_running_seconds")
+                             .Name("time_running_seconds_total")
                              .Help("How many seconds is this server running?")
                              .Labels({{"label", "value"}})
                              .Register(*registry);

--- a/pull/src/handler.cc
+++ b/pull/src/handler.cc
@@ -19,12 +19,12 @@ MetricsHandler::MetricsHandler(
     : collectables_(collectables),
       bytes_transferred_family_(
           BuildCounter()
-              .Name("exposer_bytes_transferred")
-              .Help("bytesTransferred to metrics services")
+              .Name("exposer_transferred_bytes_total")
+              .Help("Transferred bytes to metrics services")
               .Register(registry)),
       bytes_transferred_(bytes_transferred_family_.Add({})),
       num_scrapes_family_(BuildCounter()
-                              .Name("exposer_total_scrapes")
+                              .Name("exposer_scrapes_total")
                               .Help("Number of times metrics were scraped")
                               .Register(registry)),
       num_scrapes_(num_scrapes_family_.Add({})),

--- a/pull/tests/integration/BUILD.bazel
+++ b/pull/tests/integration/BUILD.bazel
@@ -14,3 +14,13 @@ sh_test(
     ],
     tags = ["manual"],
 )
+
+sh_test(
+    name = "lint-test",
+    size = "small",
+    srcs = ["lint.sh"],
+    data = [
+        "sample-server",
+    ],
+    tags = ["manual"],
+)

--- a/pull/tests/integration/lint.sh
+++ b/pull/tests/integration/lint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+curl=$(which curl)
+if [ ! -x "$curl" ] ; then
+    echo "curl must be in path for this test to run"
+    exit 1
+fi
+
+promtool=$(which promtool)
+if [ ! -x "$promtool" ] ; then
+    echo "promtool must be in path for this test to run"
+    exit 1
+fi
+
+pull/tests/integration/sample-server&
+sample_server_pid=$!
+
+function stop_server {
+  echo "Stopping sample-server"
+  kill -9 $sample_server_pid
+}
+trap stop_server EXIT
+
+sleep 1
+
+"$curl" -s http://localhost:8080/metrics | "$promtool" check metrics

--- a/pull/tests/integration/sample_server.cc
+++ b/pull/tests/integration/sample_server.cc
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
   // add a new counter family to the registry (families combine values with the
   // same name, but distinct label dimensions)
   auto& counter_family = BuildCounter()
-                             .Name("time_running_seconds")
+                             .Name("time_running_seconds_total")
                              .Help("How many seconds is this server running?")
                              .Labels({{"label", "value"}})
                              .Register(*registry);

--- a/pull/tests/integration/scrape.sh
+++ b/pull/tests/integration/scrape.sh
@@ -17,8 +17,8 @@ if [ $telegraf_run_result -ne 0 ] ; then
     exit $telegraf_run_result
 fi
 
-if [[ ! $telegraf_output == *"time_running_seconds"* ]] ; then
-   echo "Could not find time_running_seconds in exposed metrics:"
+if [[ ! $telegraf_output == *"time_running_seconds_total"* ]] ; then
+   echo "Could not find time_running_seconds_total in exposed metrics:"
    echo "${telegraf_run_output}"
    exit 1
 fi

--- a/push/tests/integration/sample_client.cc
+++ b/push/tests/integration/sample_client.cc
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
   // add a new counter family to the registry (families combine values with the
   // same name, but distinct label dimensions)
   auto& counter_family = BuildCounter()
-                             .Name("time_running_seconds")
+                             .Name("time_running_seconds_total")
                              .Help("How many seconds is this server running?")
                              .Labels({{"label", "value"}})
                              .Register(*registry);


### PR DESCRIPTION
The sample_server is now `promtool check`-clean.

See: https://prometheus.io/docs/practices/naming/

Issue: #89