### PR TITLE
Added support for shared object output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,13 @@ option(ENABLE_PULL "Build prometheus-cpp pull library" ON)
 option(ENABLE_PUSH "Build prometheus-cpp push library" ON)
 option(ENABLE_COMPRESSION "Enable gzip compression" ON)
 option(ENABLE_TESTING "Build tests" ON)
+option(ENABLE_SHARED_BUILD "Enable shared library build" OFF)
 option(USE_THIRDPARTY_LIBRARIES "Use 3rdParty submodules" ON)
 option(OVERRIDE_CXX_STANDARD_FLAGS "Force building with -std=c++11 even if the CXXLFAGS are configured differently" ON)
+
+if(ENABLE_SHARED_BUILD)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 if(OVERRIDE_CXX_STANDARD_FLAGS)
   set(CMAKE_CXX_STANDARD 11)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-add_library(core
+set(sources 
   src/check_names.cc
   src/counter.cc
   src/detail/ckms_quantiles.cc
@@ -14,7 +13,9 @@ add_library(core
   src/serializer.cc
   src/summary.cc
   src/text_serializer.cc
-)
+  )
+
+add_library(core STATIC ${sources})
 
 add_library(${PROJECT_NAME}::core ALIAS core)
 
@@ -30,6 +31,35 @@ target_include_directories(core
 )
 
 set_target_properties(core PROPERTIES OUTPUT_NAME ${PROJECT_NAME}-core)
+
+if (ENABLE_SHARED_BUILD)
+add_library(core_shared SHARED ${sources})
+
+add_library(${PROJECT_NAME}::core_shared ALIAS core_shared)
+
+target_link_libraries(core_shared
+  PRIVATE
+    Threads::Threads
+    $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
+)
+
+target_include_directories(core_shared
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+set_target_properties(core_shared PROPERTIES OUTPUT_NAME ${PROJECT_NAME}-core)
+
+install(
+  TARGETS core_shared
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+endif()
+
 
 install(
   TARGETS core

--- a/pull/CMakeLists.txt
+++ b/pull/CMakeLists.txt
@@ -9,10 +9,14 @@ if(ENABLE_COMPRESSION)
   find_package(ZLIB REQUIRED)
 endif()
 
-add_library(pull
+set(sources
   src/exposer.cc
   src/handler.cc
   src/handler.h
+)
+
+add_library(pull STATIC
+  ${sources}
   $<$<BOOL:${USE_THIRDPARTY_LIBRARIES}>:$<TARGET_OBJECTS:civetweb>>
 )
 
@@ -50,6 +54,47 @@ install(
   ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+if (ENABLE_SHARED_BUILD)
+add_library(pull_shared SHARED
+  ${sources}
+  $<$<BOOL:${USE_THIRDPARTY_LIBRARIES}>:$<TARGET_OBJECTS:civetweb>>
+)
+add_library(${PROJECT_NAME}::pull_shared ALIAS pull_shared)
+
+target_link_libraries(pull_shared
+  PUBLIC
+    ${PROJECT_NAME}::core
+  PRIVATE
+    Threads::Threads
+    ${CIVETWEB_LIBRARIES}
+    $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
+    $<$<BOOL:${ENABLE_COMPRESSION}>:ZLIB::ZLIB>
+)
+
+target_include_directories(pull_shared
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CIVETWEB_INCLUDE_DIRS}
+)
+
+target_compile_definitions(pull_shared
+  PRIVATE
+    $<$<BOOL:${ENABLE_COMPRESSION}>:HAVE_ZLIB>
+)
+
+set_target_properties(pull_shared PROPERTIES OUTPUT_NAME ${PROJECT_NAME}-pull)
+
+install(
+  TARGETS pull_shared
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+endif()
 
 install(
   DIRECTORY include/

--- a/push/CMakeLists.txt
+++ b/push/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 find_package(CURL REQUIRED)
 
-add_library(push
+add_library(push STATIC
   src/gateway.cc
 )
 
@@ -33,6 +33,41 @@ install(
   ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+if (ENABLE_SHARED_BUILD)
+add_library(push_shared SHARED
+  src/gateway.cc
+)
+
+add_library(${PROJECT_NAME}::push_shared ALIAS push_shared)
+
+target_link_libraries(push_shared
+  PUBLIC
+    ${PROJECT_NAME}::core
+  PRIVATE
+    Threads::Threads
+    ${CURL_LIBRARIES}
+    $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
+)
+
+target_include_directories(push_shared
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CURL_INCLUDE_DIRS}
+)
+
+set_target_properties(push_shared PROPERTIES OUTPUT_NAME ${PROJECT_NAME}-push)
+
+install(
+  TARGETS push_shared
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+endif()
 
 install(
   DIRECTORY include/


### PR DESCRIPTION
I wanted to use the library in a project that already contained code built with the -fPIC option. Would it be possible to allow the building of process independent code to produce shared libraries?