### PR TITLE
configure number of threads used by Exposer

### DIFF
--- a/pull/include/prometheus/exposer.h
+++ b/pull/include/prometheus/exposer.h
@@ -20,7 +20,8 @@ class MetricsHandler;
 class Exposer {
  public:
   explicit Exposer(const std::string& bind_address,
-                   const std::string& uri = std::string("/metrics"));
+                   const std::string& uri = std::string("/metrics"),
+                   const std::size_t num_threads = 2);
   ~Exposer();
   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable);
 

--- a/pull/src/exposer.cc
+++ b/pull/src/exposer.cc
@@ -11,9 +11,11 @@
 
 namespace prometheus {
 
-Exposer::Exposer(const std::string& bind_address, const std::string& uri)
+Exposer::Exposer(const std::string& bind_address, const std::string& uri, const std::size_t num_threads)
     : server_(new CivetServer{
-          {"listening_ports", bind_address.c_str(), "num_threads", "2"}}),
+            std::vector<std::string>{
+                "listening_ports", bind_address,
+                "num_threads", std::to_string(num_threads)}}),
       exposer_registry_(std::make_shared<Registry>()),
       metrics_handler_(
           new detail::MetricsHandler{collectables_, *exposer_registry_}),

--- a/pull/tests/integration/sample_server.cc
+++ b/pull/tests/integration/sample_server.cc
@@ -11,7 +11,7 @@ int main() {
   using namespace prometheus;
 
   // create an http server running on port 8080
-  Exposer exposer{"127.0.0.1:8080"};
+  Exposer exposer{"127.0.0.1:8080", "/metrics", 1};
 
   // create a metrics registry with component=main labels applied to all its
   // metrics


### PR DESCRIPTION
Exposer class creates two threads by default which could be too much in some cases. This pull-request allows to configure number of threads used by an exposer.