### PR TITLE
Only check label names when inserting a metric into a family

### DIFF
--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -146,13 +146,6 @@ template <typename T>
 template <typename... Args>
 T& Family<T>::Add(const std::map<std::string, std::string>& labels,
                   Args&&... args) {
-#ifndef NDEBUG
-  for (auto& label_pair : labels) {
-    auto& label_name = label_pair.first;
-    assert(CheckLabelName(label_name));
-  }
-#endif
-
   auto hash = detail::hash_labels(labels);
   std::lock_guard<std::mutex> lock{mutex_};
   auto metrics_iter = metrics_.find(hash);
@@ -166,6 +159,13 @@ T& Family<T>::Add(const std::map<std::string, std::string>& labels,
 #endif
     return *metrics_iter->second;
   } else {
+#ifndef NDEBUG
+    for (auto& label_pair : labels) {
+      auto& label_name = label_pair.first;
+      assert(CheckLabelName(label_name));
+    }
+#endif
+
     auto metric =
         metrics_.insert(std::make_pair(hash, detail::make_unique<T>(args...)));
     assert(metric.second);


### PR DESCRIPTION
**Background:**
I'm using prometheus-cpp to expose metrics from a program. I don't want to cache metrics within the program because we have a large number of metrics and that would be difficult to manage, and prometheus-cpp already provides caching function in `Family<T>::Add`. Since I'm not caching metrics, I don't know which metrics have already been created and which haven't, so I always call `Add`  before `Increment`/`Set`/`Observe`.

e.g.

```
prometheus::Counter& counter = counter_family.Add({{"foo", "bar"}});
counter.Increment();
```

**Problem:**
I did some analysis of my program and found that it was spending more time doing stat updates than what I expected from your benchmarks. The majority of this time was spent in the `CheckLabelName` function which is called by `Family<T>::Add`. `CheckLabelName` does a regex match which is typically expensive.

**Fix:**
`Family<T>::Add` calls `CheckLabelName` every time it is invoked, even if the metric already exists in the map. The change I've made means we only call `CheckLabelName` when inserting a new metric into the map, not when retrieving an existing metric from the map. This still checks label names for each metric (on insertion) but makes retrieving existing metrics less expensive. I saw a significant performance improvement when I tested with this change.