### PR TITLE
Add link to jupp0r.github.io/prometheus-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ other push/pull collections can be added as plugins.
 
 ## Usage
 
+See https://jupp0r.github.io/prometheus-cpp for more detailed interface documentation.
+
 ``` c++
 #include <chrono>
 #include <map>


### PR DESCRIPTION
Was trying to find some docs and couldn't find anything until I found #11. Think it would be easier if there was a link in the readme