### PR TITLE
Allow more than 1 histogram observation at a time

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -31,7 +31,7 @@ class Histogram {
 
   static const MetricType metric_type{MetricType::Histogram};
 
-  /// \brief Create a histogram with manually choosen buckets.
+  /// \brief Create a histogram with manually chosen buckets.
   ///
   /// The BucketBoundaries are a list of monotonically increasing values
   /// representing the bucket boundaries. Each consecutive pair of values is
@@ -50,6 +50,14 @@ class Histogram {
   /// b_n+1). The counter of the observed bucket is incremented. Also the total
   /// sum of all observations is incremented.
   void Observe(double value);
+
+  /// \brief Observe multiple data points.
+  ///
+  /// Increments counters given a count for each bucket. (i.e. the caller of
+  /// this function must have already sorted the values into buckets).
+  /// Also increments the total sum of all observations by the given value.
+  void ObserveMultiple(const std::vector<double> bucket_increments,
+                       const double sum_of_values);
 
   /// \brief Get the current value of the counter.
   ///

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -24,6 +24,15 @@ void Histogram::Observe(const double value) {
   bucket_counts_[bucket_index].Increment();
 }
 
+void Histogram::ObserveMultiple(const std::vector<double> bucket_increments,
+                                const double sum_of_values) {
+  sum_.Increment(sum_of_values);
+
+  for (std::size_t i{0}; i < bucket_counts_.size(); ++i) {
+    { bucket_counts_[i].Increment(bucket_increments[i]); }
+  }
+}
+
 ClientMetric Histogram::Collect() const {
   auto metric = ClientMetric{};
 

--- a/core/tests/histogram_test.cc
+++ b/core/tests/histogram_test.cc
@@ -79,5 +79,27 @@ TEST(HistogramTest, cumulative_bucket_count) {
   EXPECT_EQ(h.bucket.at(2).cumulative_count, 7U);
 }
 
+TEST(HistogramTest, observe_multiple_test_bucket_counts) {
+  Histogram histogram{{1, 2}};
+  histogram.ObserveMultiple({5, 9, 3}, 20);
+  histogram.ObserveMultiple({0, 20, 6}, 34);
+  auto metric = histogram.Collect();
+  auto h = metric.histogram;
+  ASSERT_EQ(h.bucket.size(), 3U);
+  EXPECT_EQ(h.bucket.at(0).cumulative_count, 5U);
+  EXPECT_EQ(h.bucket.at(1).cumulative_count, 34U);
+  EXPECT_EQ(h.bucket.at(2).cumulative_count, 43U);
+}
+
+TEST(HistogramTest, observe_multiple_test_total_sum) {
+  Histogram histogram{{1, 2}};
+  histogram.ObserveMultiple({5, 9, 3}, 20);
+  histogram.ObserveMultiple({0, 20, 6}, 34);
+  auto metric = histogram.Collect();
+  auto h = metric.histogram;
+  EXPECT_EQ(h.sample_count, 43U);
+  EXPECT_EQ(h.sample_sum, 54);
+}
+
 }  // namespace
 }  // namespace prometheus


### PR DESCRIPTION
Added the ObserveMultiple method to the Histogram. This is useful
if you have already have values sorted into buckets, and the sum of
the values but no longer have the individual values.