### PR TITLE
avoid infinite loop when counter is incremented from multiple threads

### DIFF
--- a/core/src/gauge.cc
+++ b/core/src/gauge.cc
@@ -29,7 +29,7 @@ void Gauge::Set(const double value) { value_.store(value); }
 void Gauge::Change(const double value) {
   auto current = value_.load();
   while (!value_.compare_exchange_weak(current, current + value))
-    ;
+    current = value_.load();
 }
 
 void Gauge::SetToCurrentTime() {


### PR DESCRIPTION
It seems that gauge/counter increment could cause infinite loop in case it is changed from different thread betwen value load and compare_exchange_weak operation.
When compare_exchange_weak fails new value must to be read to be able to succeed at some point.