### PR TITLE
Fix Histogram::ObserveMultiple bug. Now throw length_error if the num…

### DIFF
--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -26,6 +26,11 @@ void Histogram::Observe(const double value) {
 
 void Histogram::ObserveMultiple(const std::vector<double> bucket_increments,
                                 const double sum_of_values) {
+  if (bucket_increments.size() != bucket_counts_.size()) {
+    throw std::length_error("The size of bucket_increments was not equal to"
+                            "the number of buckets in the histogram.");
+  }
+
   sum_.Increment(sum_of_values);
 
   for (std::size_t i{0}; i < bucket_counts_.size(); ++i) {

--- a/core/tests/histogram_test.cc
+++ b/core/tests/histogram_test.cc
@@ -101,5 +101,13 @@ TEST(HistogramTest, observe_multiple_test_total_sum) {
   EXPECT_EQ(h.sample_sum, 54);
 }
 
+TEST(HistogramTest, observe_multiple_test_length_error) {
+  Histogram histogram{{1, 2}};
+  // 2 bucket boundaries means there are 3 buckets, so giving just 2 bucket
+  // increments should result in a length_error.
+  ASSERT_THROW(histogram.ObserveMultiple({5, 9}, 20),
+               std::length_error);
+}
+
 }  // namespace
 }  // namespace prometheus


### PR DESCRIPTION
…ber of bucket increments is not equal to the number of buckets in the histogram.