### PR TITLE
add prometheus variable labels and WithLabelValues support

### DIFF
--- a/core/benchmarks/registry_bench.cc
+++ b/core/benchmarks/registry_bench.cc
@@ -41,3 +41,37 @@ static void BM_Registry_CreateCounter(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_Registry_CreateCounter)->Range(0, 4096);
+
+static void BM_Registry_CreateCounter_WithLabelValues(benchmark::State& state) {
+  using prometheus::BuildCounter;
+  using prometheus::Counter;
+  using prometheus::Registry;
+  Registry registry;
+
+  const auto& labels = GenerateRandomLabels(state.range(0));
+  std::vector<std::string> label_names;
+  std::vector<std::string> label_values;
+  std::for_each(labels.begin(), labels.end(),
+          [&](const std::pair<std::string,std::string>& p){
+    label_names.push_back(p.first);
+    label_values.push_back(p.second);
+  });
+
+  auto& counter_family = BuildCounter()
+          .Labels(GenerateRandomLabels(10))
+          .Name("benchmark_counter")
+          .Help("")
+          .LabelsVec(label_names)
+          .Register(registry);
+
+  while (state.KeepRunning()) {
+    auto start = std::chrono::high_resolution_clock::now();
+    counter_family.WithLabelValues(label_values);
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto elapsed_seconds =
+            std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
+    state.SetIterationTime(elapsed_seconds.count());
+  }
+}
+BENCHMARK(BM_Registry_CreateCounter_WithLabelValues)->Range(0, 4096);

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -63,6 +63,22 @@ class Counter {
 ///                            .Labels({{"key", "value"}})
 ///                            .Register(*registry);
 ///
+/// counter_family.Add({{"key2","value2"}}).Increment();
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& counter_family = prometheus::BuildCounter()
+///                            .Name("some_name")
+///                            .Help("Additional description.")
+///                            .Labels({{"key", "value"}})
+///                            .LabelsVec({"key2","key3"})
+///                            .Register(*registry);
+///
+/// counter_family.WithLabelValues({"value2","value3"}).Increment();
 /// ...
 /// \endcode
 ///
@@ -73,6 +89,9 @@ class Counter {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
 ///
 /// To finish the configuration of the Counter metric, register it with
 /// Register(Registry&).

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -2,13 +2,19 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
+#include "prometheus/detail/ckms_quantiles.h"
 #include "prometheus/registry.h"
 
 namespace prometheus {
 
 template <typename T>
 class Family;
+class Guage;
+class Counter;
+class Summary;
+class Histogram;
 
 namespace detail {
 
@@ -16,12 +22,25 @@ template <typename T>
 class Builder {
  public:
   Builder& Labels(const std::map<std::string, std::string>& labels);
+  Builder& LabelsVec(const std::vector<std::string>& labels);
   Builder& Name(const std::string&);
   Builder& Help(const std::string&);
+
+  template <typename U= T, typename = typename std::enable_if<std::is_same<U, Summary>::value,Summary>::type>
+  Builder& Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>&);
+
+  template <typename U= T, typename = typename std::enable_if<std::is_same<U, Histogram>::value,Histogram>::type>
+  Builder& BucketBoundaries(const std::vector<double>&);
+
+//  template <typename N = T, typename = typename std::enable_if<std::is_same<T, Guage>::value || std::is_same<T, Counter>::value, Guage>::type>
   Family<T>& Register(Registry&);
 
  private:
   std::map<std::string, std::string> labels_;
+  std::vector<std::string> variable_labels_;
+  std::vector<detail::CKMSQuantiles::Quantile> quantiles_;
+  std::vector<double> bucket_boundaries_;
+
   std::string name_;
   std::string help_;
 };
@@ -31,6 +50,13 @@ Builder<T>& Builder<T>::Labels(
    const std::map<std::string, std::string>& labels) {
  labels_ = labels;
  return *this;
+}
+
+template <typename T>
+Builder<T>& Builder<T>::LabelsVec(
+        const std::vector<std::string>& labels) {
+  variable_labels_ = labels;
+  return *this;
 }
 
 template <typename T>
@@ -47,7 +73,21 @@ Builder<T>& Builder<T>::Help(const std::string& help) {
 
 template <typename T>
 Family<T>& Builder<T>::Register(Registry& registry) {
- return registry.Add<T>(name_, help_, labels_);
+ return registry.Add<T>(name_, help_, variable_labels_, labels_);
+}
+
+template<typename T>
+template<typename U, typename>
+Builder<T>& Builder<T>::Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>& quantiles) {
+  quantiles_ = quantiles;
+  return *this;
+}
+
+template<typename T>
+template<typename U, typename>
+Builder<T>& Builder<T>::BucketBoundaries(const std::vector<double>& bucket_boundaries) {
+  bucket_boundaries_ = bucket_boundaries;
+  return *this;
 }
 
 }  // namespace detail

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -32,7 +32,6 @@ class Builder {
   template <typename U= T, typename = typename std::enable_if<std::is_same<U, Histogram>::value,Histogram>::type>
   Builder& BucketBoundaries(const std::vector<double>&);
 
-//  template <typename N = T, typename = typename std::enable_if<std::is_same<T, Guage>::value || std::is_same<T, Counter>::value, Guage>::type>
   Family<T>& Register(Registry&);
 
  private:

--- a/core/include/prometheus/detail/ckms_quantiles.h
+++ b/core/include/prometheus/detail/ckms_quantiles.h
@@ -11,10 +11,10 @@ namespace detail {
 class CKMSQuantiles {
  public:
   struct Quantile {
-    const double quantile;
-    const double error;
-    const double u;
-    const double v;
+    double quantile;
+    double error;
+    double u;
+    double v;
 
     Quantile(double quantile, double error);
   };

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -149,8 +149,8 @@ class Family : public Collectable {
 
   const std::string name_;
   const std::string help_;
-  const std::map<std::string, std::string> constant_labels_;
   std::vector<std::string> variable_labels_;
+  const std::map<std::string, std::string> constant_labels_;
   std::vector<detail::CKMSQuantiles::Quantile> quantiles_;
   std::vector<double> bucket_boundaries_;
   std::mutex mutex_;

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -187,7 +187,7 @@ std::map<std::string, std::string> Family<T>::VariableLabels(const std::vector<s
   for (auto str : variable_labels_) {
     labels_map.emplace(str, values[i++]);
   }
-  return std::move(labels_map);
+  return labels_map;
 }
 
 template <typename T>

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -117,17 +117,24 @@ class Family : public Collectable {
   template <typename... Args>
   T& Add(const std::map<std::string, std::string>& labels, Args&&... args);
 
+  /// \brief Add a new dimensional data.
+  /// different with Add, this method call only when build<T>.LavelVec(...)
+  /// is call before.
+  /// then this method call Add
   T& WithLabelValues(const std::vector<std::string>& values);
 
+
+  /// \brief when T is Summary, set the Quantiles.
+  /// should be call before call WithLabelValues
   template <typename U = T>
   typename std::enable_if<(std::is_same<U, Summary>::value), Family<T>&>::type
   SetQuantiles(std::vector<detail::CKMSQuantiles::Quantile>& quantiles);
 
+  /// \brief when T is Summary, set the BucketBoundaries.
+  /// should be call before call WithLabelValues
   template <typename U = T>
   typename std::enable_if<(std::is_same<U, Histogram>::value), Family<T>&>::type
   SetBucketBoundaries(std::vector<double>& bucket_boundaries);
-
-
 
   /// \brief Remove the given dimensional data.
   ///

--- a/core/include/prometheus/gauge.h
+++ b/core/include/prometheus/gauge.h
@@ -75,6 +75,22 @@ class Gauge {
 ///                          .Labels({{"key", "value"}})
 ///                          .Register(*registry);
 ///
+/// gauge_family.Add({{"key2","value2"}}).Increment();
+/// ...
+/// \endcode
+///
+/// Example usage:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& gauge_family = prometheus::BuildGauge()
+///                          .Name("some_name")
+///                          .Help("Additional description.")
+///                          .Labels({{"key", "value"}})
+///                          .LabelsVec({"key2","key3"})
+///                          .Register(*registry);
+///
+/// gauge_family.WithLabelValues({"value2","value3"}).Increment();
 /// ...
 /// \endcode
 ///
@@ -85,6 +101,9 @@ class Gauge {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
 ///
 /// To finish the configuration of the Gauge metric register it with
 /// Register(Registry&).

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -84,6 +84,23 @@ class Histogram {
 ///                              .Labels({{"key", "value"}})
 ///                              .Register(*registry);
 ///
+/// histogram_family.Add({{"key1","value1"}}, Histogram::BucketBoundaries{1, 2}).Observe(1.0);
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& histogram_family = prometheus::BuildHistogram()
+///                              .Name("some_name")
+///                              .Help("Additional description.")
+///                              .Labels({{"key", "value"}})
+///                              .LabelsVec({"key2","key3"})
+///                              .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
+///                              .Register(*registry);
+///
+/// histogram_family.WithLabelValues({"value2","value3"}).Observe(1.0);
 /// ...
 /// \endcode
 ///
@@ -94,15 +111,24 @@ class Histogram {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
+/// - BucketBoundaries(const std::vector<double>&) to pre-affirmation bucketBoundaries
+///   when use WithLabelValues()
 ///
 /// To finish the configuration of the Histogram metric register it with
 /// Register(Registry&).
 detail::Builder<Histogram> BuildHistogram();
 
+
+/// \brief Specialization of WithLabelValues<Histogram>.
 template <>
 Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values);
 
 namespace detail {
+
+/// \brief Specialization of Register<Histogram>.
 template<>
 Family <Histogram> &Builder<Histogram>::Register(Registry &registry);
 

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -101,22 +101,11 @@ detail::Builder<Histogram> BuildHistogram();
 
 template <>
 Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values);
-/*{
-  assert(variable_labels_.size() == values.size());
-  std::map<std::string, std::string> labels_map(constant_labels_);
 
-  int i = 0;
-  for (auto str : variable_labels_) {
-    labels_map.emplace(str, values[i++]);
-  }
-  return Add(std::move(labels_map), bucket_boundaries_);
-}*/
-
+namespace detail {
 template<>
-Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry);
-/*{
-  Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
-  return family.SetBucketBoundaries(bucket_boundaries_);
-}*/
+Family <Histogram> &Builder<Histogram>::Register(Registry &registry);
+
+}  // namespace prometheus
 
 }  // namespace prometheus

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -99,4 +99,24 @@ class Histogram {
 /// Register(Registry&).
 detail::Builder<Histogram> BuildHistogram();
 
+template <>
+Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values);
+/*{
+  assert(variable_labels_.size() == values.size());
+  std::map<std::string, std::string> labels_map(constant_labels_);
+
+  int i = 0;
+  for (auto str : variable_labels_) {
+    labels_map.emplace(str, values[i++]);
+  }
+  return Add(std::move(labels_map), bucket_boundaries_);
+}*/
+
+template<>
+Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry);
+/*{
+  Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
+  return family.SetBucketBoundaries(bucket_boundaries_);
+}*/
+
 }  // namespace prometheus

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -48,6 +48,7 @@ class Registry : public Collectable {
 
   template <typename T>
   Family<T>& Add(const std::string& name, const std::string& help,
+                 const std::vector<std::string>& variable_labels,
                  const std::map<std::string, std::string>& labels);
 
   std::vector<std::unique_ptr<Collectable>> collectables_;
@@ -56,9 +57,10 @@ class Registry : public Collectable {
 
 template <typename T>
 Family<T>& Registry::Add(const std::string& name, const std::string& help,
+                         const std::vector<std::string>& variable_labels,
                          const std::map<std::string, std::string>& labels) {
   std::lock_guard<std::mutex> lock{mutex_};
-  auto family = detail::make_unique<Family<T>>(name, help, labels);
+  auto family = detail::make_unique<Family<T>>(name, help, variable_labels, labels);
   auto& ref = *family;
   collectables_.push_back(std::move(family));
   return ref;

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -119,4 +119,25 @@ class Summary {
 /// Register(Registry&).
 detail::Builder<Summary> BuildSummary();
 
+template <>
+Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values);
+/*{
+  assert(variable_labels_.size() == values.size());
+  std::map<std::string, std::string> labels_map(constant_labels_);
+
+  int i = 0;
+  for (auto str : variable_labels_) {
+    labels_map.emplace(str, values[i++]);
+  }
+  std::initializer_list<std::string> quantiles;
+  return Add(labels_map, quantiles_);
+}*/
+
+template<>
+Family<Summary>& detail::Builder<Summary>::Register(Registry& registry);
+/*{
+  Family<Summary>& family = registry.Add<Summary>(name_, help_, variable_labels_, labels_);
+  return family.SetQuantiles(quantiles_);
+}*/
+
 }  // namespace prometheus

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -134,7 +134,7 @@ class Summary {
 /// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
 ///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
 ///   note than: vector<names>.size() == vector<values>.size()
-/// - BucketBoundaries(const std::vector<double>&) to pre-affirmation bucketBoundaries
+/// - Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>&) to pre-affirmation Quantiles
 ///   when use WithLabelValues()
 ///
 /// To finish the configuration of the Summary metric register it with

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -104,6 +104,23 @@ class Summary {
 ///                            .Labels({{"key", "value"}})
 ///                            .Register(*registry);
 ///
+/// summary_family.Add({{"key1","value1"}}, Summary::Quantiles{}).Observe(1.0);
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& summary_family = prometheus::BuildSummary()
+///                            .Name("some_name")
+///                            .Help("Additional description.")
+///                            .Labels({{"key", "value"}})
+/////                          .LabelsVec({"key2","key3"})
+///                            .Quantiles(Summary::Quantiles{})
+///                            .Register(*registry);
+///
+/// summary_family.WithLabelValues({"value2","value3"}).Observe(1.0);
 /// ...
 /// \endcode
 ///
@@ -114,15 +131,24 @@ class Summary {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
+/// - BucketBoundaries(const std::vector<double>&) to pre-affirmation bucketBoundaries
+///   when use WithLabelValues()
 ///
 /// To finish the configuration of the Summary metric register it with
 /// Register(Registry&).
 detail::Builder<Summary> BuildSummary();
 
+
+/// \brief Specialization of WithLabelValues<Summary>.
 template <>
 Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values);
 
 namespace detail {
+
+/// \brief Specialization of Register<Summary>.
 template<>
 Family<Summary>& detail::Builder<Summary>::Register(Registry& registry);
 }  // namespace prometheus

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -121,23 +121,9 @@ detail::Builder<Summary> BuildSummary();
 
 template <>
 Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values);
-/*{
-  assert(variable_labels_.size() == values.size());
-  std::map<std::string, std::string> labels_map(constant_labels_);
 
-  int i = 0;
-  for (auto str : variable_labels_) {
-    labels_map.emplace(str, values[i++]);
-  }
-  std::initializer_list<std::string> quantiles;
-  return Add(labels_map, quantiles_);
-}*/
-
+namespace detail {
 template<>
 Family<Summary>& detail::Builder<Summary>::Register(Registry& registry);
-/*{
-  Family<Summary>& family = registry.Add<Summary>(name_, help_, variable_labels_, labels_);
-  return family.SetQuantiles(quantiles_);
-}*/
-
+}  // namespace prometheus
 }  // namespace prometheus

--- a/core/src/detail/ckms_quantiles.cc
+++ b/core/src/detail/ckms_quantiles.cc
@@ -12,7 +12,7 @@ CKMSQuantiles::Quantile::Quantile(double quantile, double error)
       error(error),
       u(2.0 * error / (1.0 - quantile)),
       v(2.0 * error / quantile) {}
-
+      
 CKMSQuantiles::Item::Item(double value, int lower_delta, int delta)
     : value(value), g(lower_delta), delta(delta) {}
 

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -59,4 +59,14 @@ ClientMetric Histogram::Collect() const {
 
 detail::Builder<Histogram> BuildHistogram() { return {}; }
 
+template <>
+Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values), bucket_boundaries_);
+}
+
+template<>
+Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry){
+  Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
+  return family.SetBucketBoundaries(bucket_boundaries_);
+}
 }  // namespace prometheus

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -64,9 +64,11 @@ Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& va
   return Add(VariableLabels(values), bucket_boundaries_);
 }
 
+namespace detail {
 template<>
 Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry){
   Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
   return family.SetBucketBoundaries(bucket_boundaries_);
 }
+}  // namespace prometheus
 }  // namespace prometheus

--- a/core/src/summary.cc
+++ b/core/src/summary.cc
@@ -36,4 +36,15 @@ ClientMetric Summary::Collect() {
 
 detail::Builder<Summary> BuildSummary() { return {}; }
 
+template <>
+Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values) {
+  return Add(VariableLabels(values), quantiles_);
+}
+
+template<>
+Family<Summary>& detail::Builder<Summary>::Register(Registry& registry){
+  Family<Summary>& family = registry.Add<Summary>(name_, help_, variable_labels_, labels_);
+  return family.SetQuantiles(quantiles_);
+}
+
 }  // namespace prometheus

--- a/core/tests/builder_test.cc
+++ b/core/tests/builder_test.cc
@@ -12,21 +12,35 @@ namespace {
 
 class BuilderTest : public testing::Test {
  protected:
+  enum class Variable { no, yes };
+
+  template <Variable v>
   std::vector<ClientMetric::Label> getExpectedLabels() {
     std::vector<ClientMetric::Label> labels;
 
-    auto gen = [](std::pair<const std::string, std::string> p) {
+    int i = 0;
+    auto gen_pair = [](std::pair<const std::string, std::string> p) {
       return ClientMetric::Label{p.first, p.second};
+    };
+    auto gen_vec = [&](const std::string k) {
+      return ClientMetric::Label{k, variable_values[i++]};
     };
 
     std::transform(std::begin(const_labels), std::end(const_labels),
-                   std::back_inserter(labels), gen);
-    std::transform(std::begin(more_labels), std::end(more_labels),
-                   std::back_inserter(labels), gen);
+            std::back_inserter(labels), gen_pair);
+    if ( v == Variable::no ) {
+      std::transform(std::begin(more_labels), std::end(more_labels),
+              std::back_inserter(labels), gen_pair);
+    }else {
+      std::transform(std::begin(variable_labels), std::end(variable_labels),
+              std::back_inserter(labels), gen_vec);
+
+    }
 
     return labels;
   }
 
+  template <Variable v>
   void verifyCollectedLabels() {
     const auto collected = registry.Collect();
 
@@ -35,17 +49,45 @@ class BuilderTest : public testing::Test {
     EXPECT_EQ(help, collected.at(0).help);
     ASSERT_EQ(1U, collected.at(0).metric.size());
 
-    EXPECT_THAT(collected.at(0).metric.at(0).label,
-                testing::UnorderedElementsAreArray(expected_labels));
+//    std::cout<<"===========got==========="<<std::endl;
+//    auto& l = collected.at(0).metric.at(0).label;
+//    std::for_each(l.begin(),l.end(),
+//                  [](const ClientMetric::Label& label){
+//                    std::cout<<label.name<<":"<<label.value<<std::endl;
+//                  });
+//    std::cout<<"===========end==========="<<std::endl;
+    if ( v == Variable::no) {
+//      std::cout<<"===========expected==========="<<std::endl;
+//      std::for_each(expected_labels.begin(),expected_variable_labels.end(),
+//                    [](const ClientMetric::Label& label){
+//                      std::cout<<label.name<<":"<<label.value<<std::endl;
+//                    });
+//      std::cout<<"=============end============="<<std::endl;
+      EXPECT_THAT(collected.at(0).metric.at(0).label,
+                  testing::UnorderedElementsAreArray(expected_labels));
+    } else {
+//      std::cout<<"===========expected==========="<<std::endl;
+//      std::for_each(expected_variable_labels.begin(),expected_variable_labels.end(),
+//                    [](const ClientMetric::Label& label){
+//                      std::cout<<label.name<<":"<<label.value<<std::endl;
+//                    });
+//      std::cout<<"=============end============="<<std::endl;
+
+      EXPECT_THAT(collected.at(0).metric.at(0).label,
+                  testing::UnorderedElementsAreArray(expected_variable_labels));
+    }
   }
 
   Registry registry;
 
   const std::string name = "some_name";
   const std::string help = "Additional description.";
+  const std::vector<std::string> variable_labels = {"vkey","vname"};
+  const std::vector<std::string> variable_values = {"vvalue","vtest"};
   const std::map<std::string, std::string> const_labels = {{"key", "value"}};
   const std::map<std::string, std::string> more_labels = {{"name", "test"}};
-  const std::vector<ClientMetric::Label> expected_labels = getExpectedLabels();
+  const std::vector<ClientMetric::Label> expected_labels = getExpectedLabels<Variable::no>();
+  const std::vector<ClientMetric::Label> expected_variable_labels = getExpectedLabels<Variable::yes>();
 };
 
 TEST_F(BuilderTest, build_counter) {
@@ -56,7 +98,7 @@ TEST_F(BuilderTest, build_counter) {
                      .Register(registry);
   family.Add(more_labels);
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
 }
 
 TEST_F(BuilderTest, build_gauge) {
@@ -67,7 +109,7 @@ TEST_F(BuilderTest, build_gauge) {
                      .Register(registry);
   family.Add(more_labels);
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
 }
 
 TEST_F(BuilderTest, build_histogram) {
@@ -78,7 +120,20 @@ TEST_F(BuilderTest, build_histogram) {
                      .Register(registry);
   family.Add(more_labels, Histogram::BucketBoundaries{1, 2});
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
+}
+
+TEST_F(BuilderTest, build_histogram_vec) {
+  auto& family = BuildHistogram()
+          .Name(name)
+          .Help(help)
+          .Labels(const_labels)
+          .LabelsVec(variable_labels)
+          .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
+          .Register(registry);
+  family.WithLabelValues(variable_values);
+
+  verifyCollectedLabels<Variable::yes>();
 }
 
 TEST_F(BuilderTest, build_summary) {
@@ -89,8 +144,20 @@ TEST_F(BuilderTest, build_summary) {
                      .Register(registry);
   family.Add(more_labels, Summary::Quantiles{});
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
 }
 
+TEST_F(BuilderTest, build_summary_vec) {
+  auto& family = BuildSummary()
+          .Name(name)
+          .Help(help)
+          .Labels(const_labels)
+          .LabelsVec(variable_labels)
+          .Quantiles(Summary::Quantiles{})
+          .Register(registry);
+  family.WithLabelValues(variable_values);
+
+  verifyCollectedLabels<Variable::yes>();
+}
 }  // namespace
 }  // namespace prometheus

--- a/core/tests/family_test.cc
+++ b/core/tests/family_test.cc
@@ -26,6 +26,22 @@ TEST(FamilyTest, labels) {
               ::testing::ElementsAre(const_label, dynamic_label));
 }
 
+TEST(FamilyTest, variable_labels) {
+  auto const_label = ClientMetric::Label{"component", "test"};
+  auto dynamic_label = ClientMetric::Label{"status", "200"};
+
+  Family<Counter> family{"total_requests",
+                         "Counts all requests",
+                         {dynamic_label.name},
+                         {{const_label.name, const_label.value}}};
+  family.WithLabelValues({{dynamic_label.value}});
+  auto collected = family.Collect();
+  ASSERT_GE(collected.size(), 1U);
+  ASSERT_GE(collected.at(0).metric.size(), 1U);
+  EXPECT_THAT(collected.at(0).metric.at(0).label,
+              ::testing::ElementsAre(const_label, dynamic_label));
+}
+
 TEST(FamilyTest, counter_value) {
   Family<Counter> family{"total_requests", "Counts all requests", {}};
   auto& counter = family.Add({});
@@ -34,6 +50,25 @@ TEST(FamilyTest, counter_value) {
   ASSERT_GE(collected.size(), 1U);
   ASSERT_GE(collected[0].metric.size(), 1U);
   EXPECT_EQ(1, collected[0].metric.at(0).counter.value);
+}
+
+TEST(FamilyTest, variable_counter_value) {
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
+  auto& counter = family.WithLabelValues({});
+  counter.Increment();
+  auto collected = family.Collect();
+  ASSERT_GE(collected.size(), 1U);
+  ASSERT_GE(collected[0].metric.size(), 1U);
+  EXPECT_EQ(1, collected[0].metric.at(0).counter.value);
+}
+
+
+TEST(FamilyTest, should_assert_error_variable_value_size) {
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
+  auto create_family_with_invalid_name = [&]() {
+    family.WithLabelValues({"haha"});
+  };
+  EXPECT_ANY_THROW(create_family_with_invalid_name());
 }
 
 TEST(FamilyTest, remove) {


### PR DESCRIPTION
we can use like this:
```c++
  auto& family = BuildHistogram()
          .Name(name)
          .Help(help)
          .Labels(const_labels)
          .LabelsVec(variable_labels)
          .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
          .Register(registry);
  family.WithLabelValues(variable_values1)..Observe(1.0);
  family.WithLabelValues(variable_values2)..Observe(2.0);


  auto& family = BuildSummary()
          .Name(name)
          .Help(help)
          .Labels(const_labels)
          .LabelsVec(variable_labels)
          .Quantiles(Summary::Quantiles{})
          .Register(registry);
  family.WithLabelValues(variable_values1).Observe(1);
  family.WithLabelValues(variable_values2).Observe(2);
```