### PR TITLE
add prometheus variable labels method(LabelVec,WithLabelValues) support

### DIFF
--- a/core/benchmarks/registry_bench.cc
+++ b/core/benchmarks/registry_bench.cc
@@ -61,7 +61,7 @@ static void BM_Registry_CreateCounter_WithLabelValues(benchmark::State& state) {
           .Labels(GenerateRandomLabels(10))
           .Name("benchmark_counter")
           .Help("")
-          .LabelsVec(label_names)
+          .LabelNamesVec(label_names)
           .Register(registry);
 
   while (state.KeepRunning()) {

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -76,7 +76,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
 ///                            .Name("some_name")
 ///                            .Help("Additional description.")
 ///                            .Labels({{"key", "value"}})
-///                            .LabelsVec({"key2","key3"})
+///                            .LabelNamesVec({"key2","key3"})
 ///                            .Register(*registry);
 ///
 /// counter_family.WithLabelValues({"value2","value3"}).Increment();
@@ -90,7 +90,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
-/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
 ///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
 ///   note than: vector<names>.size() == vector<values>.size()
 ///

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -5,6 +5,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/gauge.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 
@@ -97,5 +98,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
 /// To finish the configuration of the Counter metric, register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Counter> BuildCounter();
+
+/// \brief Specialization of WithLabelValues<Counter>.
+PROMETHEUS_CPP_CORE_EXPORT template <>
+Counter& Family<Counter>::WithLabelValues(const std::vector<std::string>& values);
 
 }  // namespace prometheus

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -64,6 +64,22 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
 ///                            .Labels({{"key", "value"}})
 ///                            .Register(*registry);
 ///
+/// counter_family.Add({{"key2","value2"}}).Increment();
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& counter_family = prometheus::BuildCounter()
+///                            .Name("some_name")
+///                            .Help("Additional description.")
+///                            .Labels({{"key", "value"}})
+///                            .LabelsVec({"key2","key3"})
+///                            .Register(*registry);
+///
+/// counter_family.WithLabelValues({"value2","value3"}).Increment();
 /// ...
 /// \endcode
 ///
@@ -74,6 +90,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
 ///
 /// To finish the configuration of the Counter metric, register it with
 /// Register(Registry&).

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -20,7 +20,7 @@ template <typename T>
 class Builder {
  public:
   Builder& Labels(const std::map<std::string, std::string>& labels);
-  Builder& LabelsVec(const std::vector<std::string>& labels);
+  Builder& LabelNamesVec(const std::vector<std::string>& labels);
   Builder& Name(const std::string&);
   Builder& Help(const std::string&);
   Family<T>& Register(Registry&);

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -1,10 +1,15 @@
 #pragma once
 
 #include <map>
+#include <vector>
 #include <string>
+#include "prometheus/detail/ckms_quantiles.h"
 
 namespace prometheus {
 
+class Counter;
+class Summary;
+class Histogram;
 template <typename T>
 class Family;
 class Registry;
@@ -15,15 +20,39 @@ template <typename T>
 class Builder {
  public:
   Builder& Labels(const std::map<std::string, std::string>& labels);
+  Builder& LabelsVec(const std::vector<std::string>& labels);
   Builder& Name(const std::string&);
   Builder& Help(const std::string&);
   Family<T>& Register(Registry&);
 
- private:
+  template <typename U= T, typename = typename std::enable_if<std::is_same<U, Summary>::value,Summary>::type>
+  Builder& Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>&);
+
+  template <typename U= T, typename = typename std::enable_if<std::is_same<U, Histogram>::value,Histogram>::type>
+  Builder& BucketBoundaries(const std::vector<double>&);
+
+private:
   std::map<std::string, std::string> labels_;
+  std::vector<std::string> variable_labels_;
+  std::vector<detail::CKMSQuantiles::Quantile> quantiles_;
+  std::vector<double> bucket_boundaries_;
   std::string name_;
   std::string help_;
 };
+
+template<typename T>
+template<typename U, typename>
+Builder<T>& Builder<T>::Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>& quantiles) {
+  quantiles_ = quantiles;
+  return *this;
+}
+
+template<typename T>
+template<typename U, typename>
+Builder<T>& Builder<T>::BucketBoundaries(const std::vector<double>& bucket_boundaries) {
+  bucket_boundaries_ = bucket_boundaries;
+  return *this;
+}
 
 }  // namespace detail
 }  // namespace prometheus

--- a/core/include/prometheus/detail/ckms_quantiles.h
+++ b/core/include/prometheus/detail/ckms_quantiles.h
@@ -13,10 +13,10 @@ namespace detail {
 class PROMETHEUS_CPP_CORE_EXPORT CKMSQuantiles {
  public:
   struct PROMETHEUS_CPP_CORE_EXPORT Quantile {
-    const double quantile;
-    const double error;
-    const double u;
-    const double v;
+    double quantile;
+    double error;
+    double u;
+    double v;
 
     Quantile(double quantile, double error);
   };

--- a/core/include/prometheus/gauge.h
+++ b/core/include/prometheus/gauge.h
@@ -6,6 +6,7 @@
 #include "prometheus/detail/builder.h"
 #include "prometheus/detail/core_export.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 
@@ -109,5 +110,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
 /// To finish the configuration of the Gauge metric register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Gauge> BuildGauge();
+
+/// \brief Specialization of WithLabelValues<Gauge>.
+PROMETHEUS_CPP_CORE_EXPORT template <>
+Gauge& Family<Gauge>::WithLabelValues(const std::vector<std::string>& values);
 
 }  // namespace prometheus

--- a/core/include/prometheus/gauge.h
+++ b/core/include/prometheus/gauge.h
@@ -88,7 +88,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
 ///                          .Name("some_name")
 ///                          .Help("Additional description.")
 ///                          .Labels({{"key", "value"}})
-///                          .LabelsVec({"key2","key3"})
+///                          .LabelNamesVec({"key2","key3"})
 ///                          .Register(*registry);
 ///
 /// gauge_family.WithLabelValues({"value2","value3"}).Increment();
@@ -102,7 +102,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
-/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
 ///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
 ///   note than: vector<names>.size() == vector<values>.size()
 ///

--- a/core/include/prometheus/gauge.h
+++ b/core/include/prometheus/gauge.h
@@ -76,6 +76,22 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
 ///                          .Labels({{"key", "value"}})
 ///                          .Register(*registry);
 ///
+/// gauge_family.Add({{"key2","value2"}}).Increment();
+/// ...
+/// \endcode
+///
+/// Example usage:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& gauge_family = prometheus::BuildGauge()
+///                          .Name("some_name")
+///                          .Help("Additional description.")
+///                          .Labels({{"key", "value"}})
+///                          .LabelsVec({"key2","key3"})
+///                          .Register(*registry);
+///
+/// gauge_family.WithLabelValues({"value2","value3"}).Increment();
 /// ...
 /// \endcode
 ///
@@ -86,6 +102,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
 ///
 /// To finish the configuration of the Gauge metric register it with
 /// Register(Registry&).

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -98,7 +98,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 ///                              .Name("some_name")
 ///                              .Help("Additional description.")
 ///                              .Labels({{"key", "value"}})
-///                              .LabelsVec({"key2","key3"})
+///                              .LabelNamesVec({"key2","key3"})
 ///                              .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
 ///                              .Register(*registry);
 ///
@@ -113,7 +113,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
-/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
 ///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
 ///   note than: vector<names>.size() == vector<values>.size()
 /// - BucketBoundaries(const std::vector<double>&) to pre-affirmation bucketBoundaries

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -7,6 +7,7 @@
 #include "prometheus/detail/builder.h"
 #include "prometheus/detail/core_export.h"
 #include "prometheus/metric_type.h"
+#include "family.h"
 
 namespace prometheus {
 
@@ -85,6 +86,23 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 ///                              .Labels({{"key", "value"}})
 ///                              .Register(*registry);
 ///
+/// histogram_family.Add({{"key1","value1"}}, Histogram::BucketBoundaries{1, 2}).Observe(1.0);
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& histogram_family = prometheus::BuildHistogram()
+///                              .Name("some_name")
+///                              .Help("Additional description.")
+///                              .Labels({{"key", "value"}})
+///                              .LabelsVec({"key2","key3"})
+///                              .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
+///                              .Register(*registry);
+///
+/// histogram_family.WithLabelValues({"value2","value3"}).Observe(1.0);
 /// ...
 /// \endcode
 ///
@@ -95,9 +113,24 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
+/// - BucketBoundaries(const std::vector<double>&) to pre-affirmation bucketBoundaries
+///   when use WithLabelValues()
 ///
 /// To finish the configuration of the Histogram metric register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Histogram> BuildHistogram();
+
+/// \brief Specialization of WithLabelValues<Histogram>.
+template <>
+Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values);
+
+namespace detail {
+/// \brief Specialization of Register<Histogram>.
+template<>
+Family <Histogram> &Builder<Histogram>::Register(Registry &registry);
+}  // namespace detail
 
 }  // namespace prometheus

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -29,6 +29,18 @@ namespace prometheus {
 /// a data race.
 class PROMETHEUS_CPP_CORE_EXPORT Histogram {
  public:
+
+  /// \brief ExponentialBuckets creates 'count' buckets, where the lowest bucket has an
+  /// upper bound of 'start' and each following bucket's upper bound is 'factor'
+  /// times the previous bucket's upper bound. The final +Inf bucket is not counted
+  /// and not included in the returned vector. The returned vector is meant to be
+  /// used for the Buckets field of Histogram.
+  ///
+  /// The function assert if 'count' is 0 or negative, if 'start' is 0 or negative,
+  /// or if 'factor' is less than or equal 1.
+  static std::vector<double> ExponentialBuckets(double begin,
+         double factor, int count);
+ public:
   using BucketBoundaries = std::vector<double>;
 
   static const MetricType metric_type{MetricType::Histogram};

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -7,7 +7,7 @@
 #include "prometheus/detail/builder.h"
 #include "prometheus/detail/core_export.h"
 #include "prometheus/metric_type.h"
-#include "family.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 
@@ -38,7 +38,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   ///
   /// The function assert if 'count' is 0 or negative, if 'start' is 0 or negative,
   /// or if 'factor' is less than or equal 1.
-  static std::vector<double> ExponentialBuckets(double begin,
+  static std::vector<double> ExponentialBuckets(double start,
          double factor, int count);
  public:
   using BucketBoundaries = std::vector<double>;
@@ -136,12 +136,12 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Histogram> BuildHistogram();
 
 /// \brief Specialization of WithLabelValues<Histogram>.
-template <>
+PROMETHEUS_CPP_CORE_EXPORT template <>
 Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values);
 
 namespace detail {
 /// \brief Specialization of Register<Histogram>.
-template<>
+PROMETHEUS_CPP_CORE_EXPORT template<>
 Family <Histogram> &Builder<Histogram>::Register(Registry &registry);
 }  // namespace detail
 

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -60,6 +60,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
 
   template <typename T>
   Family<T>& Add(const std::string& name, const std::string& help,
+                 const std::vector<std::string>& variable_labels,
                  const std::map<std::string, std::string>& labels);
 
   std::vector<std::unique_ptr<Collectable>> collectables_;

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -11,7 +11,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/detail/time_window_quantiles.h"
 #include "prometheus/metric_type.h"
-#include "family.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -11,6 +11,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/detail/time_window_quantiles.h"
 #include "prometheus/metric_type.h"
+#include "family.h"
 
 namespace prometheus {
 
@@ -105,6 +106,23 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
 ///                            .Labels({{"key", "value"}})
 ///                            .Register(*registry);
 ///
+/// summary_family.Add({{"key1","value1"}}, Summary::Quantiles{}).Observe(1.0);
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& summary_family = prometheus::BuildSummary()
+///                            .Name("some_name")
+///                            .Help("Additional description.")
+///                            .Labels({{"key", "value"}})
+/////                          .LabelsVec({"key2","key3"})
+///                            .Quantiles(Summary::Quantiles{})
+///                            .Register(*registry);
+///
+/// summary_family.WithLabelValues({"value2","value3"}).Observe(1.0);
 /// ...
 /// \endcode
 ///
@@ -115,9 +133,24 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
+/// - Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>&) to pre-affirmation Quantiles
+///   when use WithLabelValues()
 ///
 /// To finish the configuration of the Summary metric register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Summary> BuildSummary();
+
+/// \brief Specialization of WithLabelValues<Summary>.
+PROMETHEUS_CPP_CORE_EXPORT template <>
+Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values);
+
+namespace detail {
+/// \brief Specialization of Register<Summary>.
+PROMETHEUS_CPP_CORE_EXPORT template<>
+Family<Summary>& detail::Builder<Summary>::Register(Registry& registry);
+}  // namespace detail
 
 }  // namespace prometheus

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -118,7 +118,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
 ///                            .Name("some_name")
 ///                            .Help("Additional description.")
 ///                            .Labels({{"key", "value"}})
-/////                          .LabelsVec({"key2","key3"})
+/////                          .LabelNamesVec({"key2","key3"})
 ///                            .Quantiles(Summary::Quantiles{})
 ///                            .Register(*registry);
 ///
@@ -133,7 +133,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
-/// - LabelsVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
 ///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
 ///   note than: vector<names>.size() == vector<values>.size()
 /// - Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>&) to pre-affirmation Quantiles

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -18,6 +18,13 @@ Builder<T>& Builder<T>::Labels(
 }
 
 template <typename T>
+Builder<T>& Builder<T>::LabelsVec(
+        const std::vector<std::string>& labels) {
+  variable_labels_ = labels;
+  return *this;
+}
+
+template <typename T>
 Builder<T>& Builder<T>::Name(const std::string& name) {
   name_ = name;
   return *this;
@@ -31,7 +38,7 @@ Builder<T>& Builder<T>::Help(const std::string& help) {
 
 template <typename T>
 Family<T>& Builder<T>::Register(Registry& registry) {
-  return registry.Add<T>(name_, help_, labels_);
+  return registry.Add<T>(name_, help_, variable_labels_, labels_);
 }
 
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Counter>;

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -18,7 +18,7 @@ Builder<T>& Builder<T>::Labels(
 }
 
 template <typename T>
-Builder<T>& Builder<T>::LabelsVec(
+Builder<T>& Builder<T>::LabelNamesVec(
         const std::vector<std::string>& labels) {
   variable_labels_ = labels;
   return *this;

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -46,6 +46,20 @@ template class PROMETHEUS_CPP_CORE_EXPORT Builder<Gauge>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Histogram>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Summary>;
 
+
+template<>
+Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry){
+  Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
+  return family.SetBucketBoundaries(bucket_boundaries_);
+}
+
+template<>
+Family<Summary> &detail::Builder<Summary>::Register(Registry &registry) {
+  Family<Summary> &family = registry.Add<Summary>(name_, help_, variable_labels_, labels_);
+  return family.SetQuantiles(quantiles_);
+}
+
+
 }  // namespace detail
 
 detail::Builder<Counter> BuildCounter() { return {}; }

--- a/core/src/family.cc
+++ b/core/src/family.cc
@@ -121,4 +121,25 @@ template class PROMETHEUS_CPP_CORE_EXPORT Family<Gauge>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Histogram>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Summary>;
 
+
+template <>
+Gauge& Family<Gauge>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values));
+}
+
+template <>
+Counter& Family<Counter>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values));
+}
+
+template <>
+Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values) {
+  return Add(VariableLabels(values), quantiles_);
+}
+
+template <>
+Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values), bucket_boundaries_);
+}
+
 }  // namespace prometheus

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -8,6 +8,20 @@
 
 namespace prometheus {
 
+std::vector<double> Histogram::ExponentialBuckets(double start,
+        double factor, int count) {
+  assert(count >= 1);
+  assert(start > 0);
+  assert(factor > 1);
+
+  std::vector<double> buckets;
+  for (int i=0; i < count; i++) {
+    buckets.push_back(start);
+    start *= factor;
+  }
+  return buckets;
+}
+
 Histogram::Histogram(const BucketBoundaries& buckets)
     : bucket_boundaries_{buckets}, bucket_counts_{buckets.size() + 1}, sum_{} {
   assert(std::is_sorted(std::begin(bucket_boundaries_),
@@ -60,18 +74,5 @@ ClientMetric Histogram::Collect() const {
 
   return metric;
 }
-
-template <>
-Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values) {\
-  return Add(VariableLabels(values), bucket_boundaries_);
-}
-
-namespace detail {
-template<>
-Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry){
-  Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
-  return family.SetBucketBoundaries(bucket_boundaries_);
-}
-}  // namespace detail
 
 }  // namespace prometheus

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -1,4 +1,5 @@
 #include "prometheus/histogram.h"
+#include "prometheus/registry.h"
 
 #include <algorithm>
 #include <cassert>
@@ -59,5 +60,18 @@ ClientMetric Histogram::Collect() const {
 
   return metric;
 }
+
+template <>
+Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values), bucket_boundaries_);
+}
+
+namespace detail {
+template<>
+Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry){
+  Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
+  return family.SetBucketBoundaries(bucket_boundaries_);
+}
+}  // namespace detail
 
 }  // namespace prometheus

--- a/core/src/registry.cc
+++ b/core/src/registry.cc
@@ -27,9 +27,10 @@ std::vector<MetricFamily> Registry::Collect() {
 
 template <typename T>
 Family<T>& Registry::Add(const std::string& name, const std::string& help,
+                         const std::vector<std::string>& variable_labels,
                          const std::map<std::string, std::string>& labels) {
   std::lock_guard<std::mutex> lock{mutex_};
-  auto family = detail::make_unique<Family<T>>(name, help, labels);
+  auto family = detail::make_unique<Family<T>>(name, help, variable_labels, labels);
   auto& ref = *family;
   collectables_.push_back(std::move(family));
   return ref;
@@ -37,18 +38,22 @@ Family<T>& Registry::Add(const std::string& name, const std::string& help,
 
 template Family<Counter>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 template Family<Gauge>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 template Family<Summary>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 template Family<Histogram>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 }  // namespace prometheus

--- a/core/src/summary.cc
+++ b/core/src/summary.cc
@@ -3,6 +3,19 @@
 
 namespace prometheus {
 
+std::vector<double> ExponentialBuckets(double start,
+        double factor, int count) {
+  assert(count >= 1);
+  assert(start > 1);
+  assert(factor > 1);
+
+  std::vector<double> buckets;
+  for (int i=0; i < count; i++) {
+    buckets.push_back(start);
+    start *= factor;
+  }
+  return buckets;
+}
 Summary::Summary(const Quantiles& quantiles,
                  const std::chrono::milliseconds max_age, const int age_buckets)
     : quantiles_{quantiles},

--- a/core/src/summary.cc
+++ b/core/src/summary.cc
@@ -3,19 +3,6 @@
 
 namespace prometheus {
 
-std::vector<double> ExponentialBuckets(double start,
-        double factor, int count) {
-  assert(count >= 1);
-  assert(start > 1);
-  assert(factor > 1);
-
-  std::vector<double> buckets;
-  for (int i=0; i < count; i++) {
-    buckets.push_back(start);
-    start *= factor;
-  }
-  return buckets;
-}
 Summary::Summary(const Quantiles& quantiles,
                  const std::chrono::milliseconds max_age, const int age_buckets)
     : quantiles_{quantiles},
@@ -47,18 +34,5 @@ ClientMetric Summary::Collect() {
 
   return metric;
 }
-
-template <>
-Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values) {
-  return Add(VariableLabels(values), quantiles_);
-}
-
-namespace detail {
-template<>
-Family<Summary> &detail::Builder<Summary>::Register(Registry &registry) {
-  Family<Summary> &family = registry.Add<Summary>(name_, help_, variable_labels_, labels_);
-  return family.SetQuantiles(quantiles_);
-}
-} // namespace detail
 
 }  // namespace prometheus

--- a/core/src/summary.cc
+++ b/core/src/summary.cc
@@ -1,4 +1,5 @@
 #include "prometheus/summary.h"
+#include "prometheus/registry.h"
 
 namespace prometheus {
 
@@ -33,5 +34,18 @@ ClientMetric Summary::Collect() {
 
   return metric;
 }
+
+template <>
+Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values) {
+  return Add(VariableLabels(values), quantiles_);
+}
+
+namespace detail {
+template<>
+Family<Summary> &detail::Builder<Summary>::Register(Registry &registry) {
+  Family<Summary> &family = registry.Add<Summary>(name_, help_, variable_labels_, labels_);
+  return family.SetQuantiles(quantiles_);
+}
+} // namespace detail
 
 }  // namespace prometheus

--- a/core/tests/builder_test.cc
+++ b/core/tests/builder_test.cc
@@ -129,7 +129,7 @@ TEST_F(BuilderTest, build_histogram_vec) {
           .Name(name)
           .Help(help)
           .Labels(const_labels)
-          .LabelsVec(variable_labels)
+          .LabelNamesVec(variable_labels)
           .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
           .Register(registry);
   family.WithLabelValues(variable_values);
@@ -153,7 +153,7 @@ TEST_F(BuilderTest, build_summary_vec) {
           .Name(name)
           .Help(help)
           .Labels(const_labels)
-          .LabelsVec(variable_labels)
+          .LabelNamesVec(variable_labels)
           .Quantiles(Summary::Quantiles{})
           .Register(registry);
   family.WithLabelValues(variable_values);

--- a/core/tests/builder_test.cc
+++ b/core/tests/builder_test.cc
@@ -12,21 +12,36 @@ namespace {
 
 class BuilderTest : public testing::Test {
  protected:
+  enum class Variable { no, yes };
+
+  template <Variable v>
   std::vector<ClientMetric::Label> getExpectedLabels() {
     std::vector<ClientMetric::Label> labels;
 
-    auto gen = [](std::pair<const std::string, std::string> p) {
+    int i = 0;
+    auto gen_pair = [](std::pair<const std::string, std::string> p) {
       return ClientMetric::Label{p.first, p.second};
     };
+    auto gen_vec = [&](const std::string k) {
+      return ClientMetric::Label{k, variable_values[i++]};
+    };
+
 
     std::transform(std::begin(const_labels), std::end(const_labels),
-                   std::back_inserter(labels), gen);
-    std::transform(std::begin(more_labels), std::end(more_labels),
-                   std::back_inserter(labels), gen);
+                   std::back_inserter(labels), gen_pair);
+    if ( v == Variable::no ) {
+      std::transform(std::begin(more_labels), std::end(more_labels),
+                     std::back_inserter(labels), gen_pair);
+    }else {
+      std::transform(std::begin(variable_labels), std::end(variable_labels),
+                     std::back_inserter(labels), gen_vec);
+
+    }
 
     return labels;
   }
 
+  template <Variable v>
   void verifyCollectedLabels() {
     const auto collected = registry.Collect();
 
@@ -35,17 +50,45 @@ class BuilderTest : public testing::Test {
     EXPECT_EQ(help, collected.at(0).help);
     ASSERT_EQ(1U, collected.at(0).metric.size());
 
-    EXPECT_THAT(collected.at(0).metric.at(0).label,
-                testing::UnorderedElementsAreArray(expected_labels));
+    //    std::cout<<"===========got==========="<<std::endl;
+//    auto& l = collected.at(0).metric.at(0).label;
+//    std::for_each(l.begin(),l.end(),
+//                  [](const ClientMetric::Label& label){
+//                    std::cout<<label.name<<":"<<label.value<<std::endl;
+//                  });
+//    std::cout<<"===========end==========="<<std::endl;
+    if ( v == Variable::no) {
+//      std::cout<<"===========expected==========="<<std::endl;
+//      std::for_each(expected_labels.begin(),expected_variable_labels.end(),
+//                    [](const ClientMetric::Label& label){
+//                      std::cout<<label.name<<":"<<label.value<<std::endl;
+//                    });
+//      std::cout<<"=============end============="<<std::endl;
+      EXPECT_THAT(collected.at(0).metric.at(0).label,
+                  testing::UnorderedElementsAreArray(expected_labels));
+    } else {
+//      std::cout<<"===========expected==========="<<std::endl;
+//      std::for_each(expected_variable_labels.begin(),expected_variable_labels.end(),
+//                    [](const ClientMetric::Label& label){
+//                      std::cout<<label.name<<":"<<label.value<<std::endl;
+//                    });
+//      std::cout<<"=============end============="<<std::endl;
+
+      EXPECT_THAT(collected.at(0).metric.at(0).label,
+                  testing::UnorderedElementsAreArray(expected_variable_labels));
+    }
   }
 
   Registry registry;
 
   const std::string name = "some_name";
   const std::string help = "Additional description.";
+  const std::vector<std::string> variable_labels = {"vkey","vname"};
+  const std::vector<std::string> variable_values = {"vvalue","vtest"};
   const std::map<std::string, std::string> const_labels = {{"key", "value"}};
   const std::map<std::string, std::string> more_labels = {{"name", "test"}};
-  const std::vector<ClientMetric::Label> expected_labels = getExpectedLabels();
+  const std::vector<ClientMetric::Label> expected_labels = getExpectedLabels<Variable::no>();
+  const std::vector<ClientMetric::Label> expected_variable_labels = getExpectedLabels<Variable::yes>();
 };
 
 TEST_F(BuilderTest, build_counter) {
@@ -56,7 +99,7 @@ TEST_F(BuilderTest, build_counter) {
                      .Register(registry);
   family.Add(more_labels);
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
 }
 
 TEST_F(BuilderTest, build_gauge) {
@@ -67,7 +110,7 @@ TEST_F(BuilderTest, build_gauge) {
                      .Register(registry);
   family.Add(more_labels);
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
 }
 
 TEST_F(BuilderTest, build_histogram) {
@@ -78,7 +121,20 @@ TEST_F(BuilderTest, build_histogram) {
                      .Register(registry);
   family.Add(more_labels, Histogram::BucketBoundaries{1, 2});
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
+}
+
+TEST_F(BuilderTest, build_histogram_vec) {
+  auto& family = BuildHistogram()
+          .Name(name)
+          .Help(help)
+          .Labels(const_labels)
+          .LabelsVec(variable_labels)
+          .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
+          .Register(registry);
+  family.WithLabelValues(variable_values);
+
+  verifyCollectedLabels<Variable::yes>();
 }
 
 TEST_F(BuilderTest, build_summary) {
@@ -89,7 +145,20 @@ TEST_F(BuilderTest, build_summary) {
                      .Register(registry);
   family.Add(more_labels, Summary::Quantiles{});
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
+}
+
+TEST_F(BuilderTest, build_summary_vec) {
+  auto& family = BuildSummary()
+          .Name(name)
+          .Help(help)
+          .Labels(const_labels)
+          .LabelsVec(variable_labels)
+          .Quantiles(Summary::Quantiles{})
+          .Register(registry);
+  family.WithLabelValues(variable_values);
+
+  verifyCollectedLabels<Variable::yes>();
 }
 
 }  // namespace

--- a/pull/tests/integration/sample_server.cc
+++ b/pull/tests/integration/sample_server.cc
@@ -24,6 +24,7 @@ int main() {
                              .Name("time_running_seconds_total")
                              .Help("How many seconds is this server running?")
                              .Labels({{"label", "value"}})
+                             .LabelNamesVec({"label", "value"})
                              .Register(*registry);
 
   // add a counter to the metric family
@@ -37,6 +38,7 @@ int main() {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     // increment the counter by one (second)
     second_counter.Increment();
+    counter_family.WithLabelValues({"v1", "v2"}).Increment();
   }
   return 0;
 }


### PR DESCRIPTION
we can use like this:
```c++
auto& family = BuildHistogram()
          .Name(name)
          .Help(help)
          .Labels(const_labels)
          .LabelNamesVec(variable_labels)
          .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
          .Register(registry);
  family.WithLabelValues(variable_values1).Observe(1.0);
  family.WithLabelValues(variable_values2).Observe(2.0);


  auto& family = BuildSummary()
          .Name(name)
          .Help(help)
          .Labels(const_labels)
          .LabelNamesVec(variable_labels)
          .Quantiles(Summary::Quantiles{})
          .Register(registry);
  family.WithLabelValues(variable_values1).Observe(1);
  family.WithLabelValues(variable_values2).Observe(2);
```