### PR TITLE
fix(github): Use macos-latest

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         buildsystem: [bazel, cmake]
-        os: [macOS-10.14, ubuntu-16.04, windows-2016]
+        os: [macOS-latest, ubuntu-16.04, windows-2016]
     steps:
       - uses: actions/checkout@master
         with:


### PR DESCRIPTION
Github updates the macos fleet to catalina and recommends
to stay on macos-latest.