### PR TITLE
CP-1664: modify prometheus-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
                              .Name("time_running_seconds_total")
                              .Help("How many seconds is this server running?")
                              .Labels({{"label", "value"}})
+                             .RetentionBehavior(prometheus::RetentionBehavior::Keep)
                              .Register(*registry);
 
   // add a counter to the metric family

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,9 +17,13 @@ add_library(core
 
 add_library(${PROJECT_NAME}::core ALIAS core)
 
+find_package(Boost REQUIRED COMPONENTS regex)
+include_directories(${Boost_INCLUDE_DIRS})
+
 target_link_libraries(core
   PRIVATE
     Threads::Threads
+    ${Boost_LIBRARIES}
     $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
 )
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(core
   src/registry.cc
   src/serializer.cc
   src/summary.cc
+  src/metric_base.cc
   src/text_serializer.cc
 )
 

--- a/core/include/prometheus/collectable.h
+++ b/core/include/prometheus/collectable.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ctime>
 #include <vector>
 
 #include "prometheus/detail/core_export.h"
@@ -21,7 +20,6 @@ class PROMETHEUS_CPP_CORE_EXPORT Collectable {
 
   /// \brief Returns a list of metrics and their samples.
   virtual std::vector<MetricFamily> Collect() = 0;
-  virtual std::vector<MetricFamily> Collect(const std::time_t&) = 0;
 };
 
 }  // namespace prometheus

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -8,6 +8,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/gauge.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/metric_base.h"
 
 namespace prometheus {
 
@@ -26,20 +27,17 @@ namespace prometheus {
 ///
 /// The class is thread-safe. No concurrent call to any API of this type causes
 /// a data race.
-class PROMETHEUS_CPP_CORE_EXPORT Counter {
+class PROMETHEUS_CPP_CORE_EXPORT Counter: public MetricBase {
  public:
   static const MetricType metric_type{MetricType::Counter};
 
   /// \brief Create a counter that starts at 0.
   Counter() = default;
 
-  /// \brief Increment the counter by 1.
-  void Increment();
-
   /// \brief Increment the counter by a given amount.
   ///
   /// The counter will not change if the given amount is negative.
-  void Increment(double);
+  void Increment(const double& = 1, const bool& alert = true);
 
   /// \brief Get the current value of the counter.
   double Value() const;
@@ -48,13 +46,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
   ///
   /// Collect is called by the Registry when collecting metrics.
   ClientMetric Collect() const;
-  void UpdateRetentionTime(const double& retention_time, const bool& bump = true);
-  bool Expired() const;
 
  private:
-  Gauge gauge_{0.0};
-  std::atomic<double> retention_time_{1e9};
-  std::atomic<std::time_t> last_update_{std::time(nullptr)};
+  std::atomic<double> value_{0.0};
 };
 
 /// \brief Return a builder to configure and register a Counter metric.

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ctime>
+#include <atomic>
 
 #include "prometheus/client_metric.h"
 #include "prometheus/detail/builder.h"
@@ -47,10 +48,13 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
   ///
   /// Collect is called by the Registry when collecting metrics.
   ClientMetric Collect() const;
-  bool Expired(const std::time_t&, const double&) const;
+  void UpdateRetentionTime(const double& retention_time, const bool& bump = true);
+  bool Expired() const;
 
  private:
   Gauge gauge_{0.0};
+  std::atomic<double> retention_time_{1e9};
+  std::atomic<std::time_t> last_update_{std::time(nullptr)};
 };
 
 /// \brief Return a builder to configure and register a Counter metric.

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -4,10 +4,10 @@
 #include <string>
 #include <memory>
 
+#include "prometheus/family.h"
+
 namespace prometheus {
 
-template <typename T>
-class Family;
 class Registry;
 
 namespace detail {
@@ -15,12 +15,14 @@ namespace detail {
 template <typename T>
 class Builder {
  public:
+  Builder& RetentionBehavior(const prometheus::RetentionBehavior& retention_behavior);
   Builder& Labels(const std::map<std::string, std::string>& labels);
   Builder& Name(const std::string&);
   Builder& Help(const std::string&);
   std::shared_ptr<Family<T>> Register(Registry&);
 
  private:
+  prometheus::RetentionBehavior retention_behavior_ = prometheus::RetentionBehavior::Keep;
   std::map<std::string, std::string> labels_;
   std::string name_;
   std::string help_;

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -17,14 +17,12 @@ class Builder {
   Builder& Labels(const std::map<std::string, std::string>& labels);
   Builder& Name(const std::string&);
   Builder& Help(const std::string&);
-  Builder& Seconds(const double&);
   Family<T>& Register(Registry&);
 
  private:
   std::map<std::string, std::string> labels_;
   std::string name_;
   std::string help_;
-  double seconds_;
 };
 
 }  // namespace detail

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <string>
+#include <memory>
 
 namespace prometheus {
 
@@ -17,7 +18,7 @@ class Builder {
   Builder& Labels(const std::map<std::string, std::string>& labels);
   Builder& Name(const std::string&);
   Builder& Help(const std::string&);
-  Family<T>& Register(Registry&);
+  std::shared_ptr<Family<T>> Register(Registry&);
 
  private:
   std::map<std::string, std::string> labels_;

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -23,6 +23,9 @@
 
 namespace prometheus {
 
+enum class RetentionBehavior {Keep, Remove};
+
+
 /// \brief A metric of type T with a set of labeled dimensions.
 ///
 /// One of Prometheus main feature is a multi-dimensional data model with time
@@ -62,7 +65,6 @@ namespace prometheus {
 template <typename T>
 class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
  public:
-  enum class RetentionBehavior {Keep, Remove};
 
   /// \brief Create a new metric.
   ///
@@ -89,8 +91,8 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   /// \param name Set the metric name.
   /// \param help Set an additional description.
   /// \param constant_labels Assign a set of key-value pairs (= labels) to the
-  /// metric. All these labels are propagated to each time series within the
-  /// metric.
+  ///        metric. All these labels are propagated to each time series within
+  ///        the metric.
   Family(const std::string& name, const std::string& help,
          const std::map<std::string, std::string>& constant_labels,
          const RetentionBehavior& retention_behavior = RetentionBehavior::Keep);

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -112,15 +112,15 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   /// \return Return the newly created dimensional data or - if a same set of
   /// labels already exists - the already existing dimensional data.
   template <typename... Args>
-  T& Add(const std::map<std::string, std::string>& labels, Args&&... args) {
-    return Add(labels, detail::make_unique<T>(std::forward<Args>(args)...));
+  std::shared_ptr<T> Add(const std::map<std::string, std::string>& labels, Args&&... args) {
+    return Add(labels, std::make_shared<T>(std::forward<Args>(args)...));
   }
 
   /// \brief Remove the given dimensional data.
   ///
   /// \param metric Dimensional data to be removed. The function does nothing,
   /// if the given metric was not returned by Add().
-  void Remove(T* metric);
+  void Remove(std::shared_ptr<T> metric);
 
   /// \brief Returns the name for this family.
   ///
@@ -142,9 +142,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   bool UpdateRetentionTime(const double& retention_time, const std::string& re_name, const std::map<std::string, std::string>& re_labels, const bool& bump = true, const bool& debug = false);
 
  private:
-  std::unordered_map<std::size_t, std::unique_ptr<T>> metrics_;
+  std::unordered_map<std::size_t, std::shared_ptr<T>> metrics_;
   std::unordered_map<std::size_t, std::map<std::string, std::string>> labels_;
-  std::unordered_map<T*, std::size_t> labels_reverse_lookup_;
+  std::unordered_map<std::shared_ptr<T>, std::size_t> labels_reverse_lookup_;
 
   const std::string name_;
   const std::string help_;
@@ -152,9 +152,8 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   RetentionBehavior retention_behavior_;
   std::mutex mutex_;
 
-  ClientMetric CollectMetric(std::size_t hash, T* metric);
-  T& Add(const std::map<std::string, std::string>& labels,
-         std::unique_ptr<T> object);
+  ClientMetric CollectMetric(std::size_t hash, std::shared_ptr<T> metric);
+  std::shared_ptr<T> Add(const std::map<std::string, std::string>& labels, std::shared_ptr<T> object);
 };
 
 }  // namespace prometheus

--- a/core/include/prometheus/gauge.h
+++ b/core/include/prometheus/gauge.h
@@ -7,6 +7,7 @@
 #include "prometheus/detail/builder.h"
 #include "prometheus/detail/core_export.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/metric_base.h"
 
 namespace prometheus {
 
@@ -22,27 +23,21 @@ namespace prometheus {
 ///
 /// The class is thread-safe. No concurrent call to any API of this type causes
 /// a data race.
-class PROMETHEUS_CPP_CORE_EXPORT Gauge {
+class PROMETHEUS_CPP_CORE_EXPORT Gauge: public MetricBase {
  public:
   static const MetricType metric_type{MetricType::Gauge};
 
   /// \brief Create a gauge that starts at the given amount.
-  Gauge(const double& = 0);
-
-  /// \brief Increment the gauge by 1.
-  void Increment();
+  Gauge(const double& value = 0);
 
   /// \brief Increment the gauge by the given amount.
-  void Increment(double);
-
-  /// \brief Decrement the gauge by 1.
-  void Decrement();
+  void Increment(const double& value = 1, const bool& alert = true);
 
   /// \brief Decrement the gauge by the given amount.
-  void Decrement(double);
+  void Decrement(const double& value = 1, const bool& alert = true);
 
   /// \brief Set the gauge to the given value.
-  void Set(double);
+  void Set(const double& value, const bool& alert = true);
 
   /// \brief Set the gauge to the current unixtime in seconds.
   void SetToCurrentTime();
@@ -53,17 +48,10 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
   /// \brief Get the current value of the gauge.
   ///
   /// Collect is called by the Registry when collecting metrics.
-  ClientMetric Collect() const;
-  void UpdateRetentionTime(const double& retention_time, const bool& bump = true);
-
-  /// \brief Check if the metric has expired
-  bool Expired() const;
+  ClientMetric Collect() const; 
 
  private:
-  void Change(double);
-  std::atomic<double> retention_time_{1e9};
   std::atomic<double> value_{0.0};
-  std::atomic<std::time_t> last_update_{std::time(nullptr)};
 };
 
 /// \brief Return a builder to configure and register a Gauge metric.

--- a/core/include/prometheus/gauge.h
+++ b/core/include/prometheus/gauge.h
@@ -26,11 +26,8 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
  public:
   static const MetricType metric_type{MetricType::Gauge};
 
-  /// \brief Create a gauge that starts at 0.
-  Gauge() = default;
-
   /// \brief Create a gauge that starts at the given amount.
-  Gauge(double);
+  Gauge(const double& = 0);
 
   /// \brief Increment the gauge by 1.
   void Increment();
@@ -57,12 +54,16 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
   ///
   /// Collect is called by the Registry when collecting metrics.
   ClientMetric Collect() const;
-  bool Expired(const std::time_t& , const double&) const;
+  void UpdateRetentionTime(const double& retention_time, const bool& bump = true);
+
+  /// \brief Check if the metric has expired
+  bool Expired() const;
 
  private:
   void Change(double);
+  std::atomic<double> retention_time_{1e9};
   std::atomic<double> value_{0.0};
-  std::atomic<std::time_t> time_{std::time(nullptr)};
+  std::atomic<std::time_t> last_update_{std::time(nullptr)};
 };
 
 /// \brief Return a builder to configure and register a Gauge metric.

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ctime>
+#include <atomic>
 #include <vector>
 
 #include "prometheus/client_metric.h"
@@ -65,12 +66,17 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   ///
   /// Collect is called by the Registry when collecting metrics.
   ClientMetric Collect() const;
-  bool Expired(const std::time_t&, const double&) const;
+  void UpdateRetentionTime(const double& retention_time, const bool& bump = true);
+
+  /// \brief Check if the metric has expired
+  bool Expired() const;
 
  private:
   const BucketBoundaries bucket_boundaries_;
   std::vector<Counter> bucket_counts_;
   Counter sum_;
+  std::atomic<double> retention_time_{1e9};
+  std::atomic<std::time_t> last_update_{std::time(nullptr)};
 };
 
 /// \brief Return a builder to configure and register a Histogram metric.

--- a/core/include/prometheus/metric_base.h
+++ b/core/include/prometheus/metric_base.h
@@ -1,0 +1,39 @@
+#pragma once
+
+
+// Local
+#include "prometheus/family.h"
+
+// CPP
+#include <ctime>
+#include <atomic>
+
+namespace prometheus {
+
+/// \brief The base class for all metrics
+class PROMETHEUS_CPP_CORE_EXPORT MetricBase {
+ public:
+  /// \brief    Prints a message to stderr if the metric doesn't have a family
+  bool HasFamily();
+
+  /// \brief    Prints a message to stderr if the metric doesn't have a family
+  void AlertIfNoFamily();
+
+  /// \brief    Update the metric's retention time
+  /// \param    retention_time the value used to set retention_time_
+  /// \param    bump if true, also update the metric's last_update time
+  void UpdateRetentionTime(const double& retention_time, const bool& bump = true);
+
+  /// \brief    Check if the metric has expired
+  bool Expired() const;
+
+  template<typename T>
+  friend class Family;
+
+ protected:
+  bool has_family_{false};
+  std::atomic<double> retention_time_{1e9};
+  std::atomic<std::time_t> last_update_{std::time(nullptr)};
+};
+
+}  // namespace prometheus

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -61,7 +61,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
   /// \brief name Create a new registry.
   ///
   /// \param insert_behavior How to handle families with the same name.
-  explicit Registry(InsertBehavior insert_behavior = InsertBehavior::Merge);
+  explicit Registry(const InsertBehavior& insert_behavior = InsertBehavior::Merge);
 
   /// \brief name Destroys a registry.
   ~Registry();
@@ -87,8 +87,10 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
   bool NameExistsInOtherType(const std::string& name) const;
 
   template <typename T>
-  std::shared_ptr<Family<T>> Add(const std::string& name, const std::string& help,
-                 const std::map<std::string, std::string>& labels);
+  std::shared_ptr<Family<T>> Add(
+                 const std::string& name, const std::string& help,
+                 const std::map<std::string, std::string>& labels,
+                 const RetentionBehavior& retention_behavior = RetentionBehavior::Keep);
 
   const InsertBehavior insert_behavior_;
   std::vector<std::shared_ptr<Family<Counter>>> counters_;

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <set>
 
 #include "prometheus/collectable.h"
 #include "prometheus/detail/core_export.h"
@@ -72,7 +73,8 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
   ///
   /// \return Zero or more metrics and their samples.
   std::vector<MetricFamily> Collect() override;
-  std::vector<MetricFamily> Collect(const std::time_t&);
+
+  bool UpdateRetentionTime(const double& retention_time, const std::string& re_name, const std::map<std::string, std::string>& re_labels, const std::set<MetricType>& families = {MetricType::Counter, MetricType::Gauge, MetricType::Summary, MetricType::Histogram}, const bool& bump = true, const bool& debug = false);
 
  private:
   template <typename T>
@@ -86,8 +88,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
 
   template <typename T>
   Family<T>& Add(const std::string& name, const std::string& help,
-                 const std::map<std::string, std::string>& labels,
-                 const double& seconds);
+                 const std::map<std::string, std::string>& labels);
 
   const InsertBehavior insert_behavior_;
   std::vector<std::unique_ptr<Family<Counter>>> counters_;

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -81,20 +81,20 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
   friend class detail::Builder;
 
   template <typename T>
-  std::vector<std::unique_ptr<Family<T>>>& GetFamilies();
+  std::vector<std::shared_ptr<Family<T>>>& GetFamilies();
 
   template <typename T>
   bool NameExistsInOtherType(const std::string& name) const;
 
   template <typename T>
-  Family<T>& Add(const std::string& name, const std::string& help,
+  std::shared_ptr<Family<T>> Add(const std::string& name, const std::string& help,
                  const std::map<std::string, std::string>& labels);
 
   const InsertBehavior insert_behavior_;
-  std::vector<std::unique_ptr<Family<Counter>>> counters_;
-  std::vector<std::unique_ptr<Family<Gauge>>> gauges_;
-  std::vector<std::unique_ptr<Family<Histogram>>> histograms_;
-  std::vector<std::unique_ptr<Family<Summary>>> summaries_;
+  std::vector<std::shared_ptr<Family<Counter>>> counters_;
+  std::vector<std::shared_ptr<Family<Gauge>>> gauges_;
+  std::vector<std::shared_ptr<Family<Histogram>>> histograms_;
+  std::vector<std::shared_ptr<Family<Summary>>> summaries_;
   std::mutex mutex_;
 };
 

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -13,6 +13,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/detail/time_window_quantiles.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/metric_base.h"
 
 namespace prometheus {
 
@@ -40,7 +41,7 @@ namespace prometheus {
 ///
 /// The class is thread-safe. No concurrent call to any API of this type causes
 /// a data race.
-class PROMETHEUS_CPP_CORE_EXPORT Summary {
+class PROMETHEUS_CPP_CORE_EXPORT Summary: public MetricBase {
  public:
   using Quantiles = std::vector<detail::CKMSQuantiles::Quantile>;
 
@@ -78,16 +79,12 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
           const int& age_buckets = 5);
 
   /// \brief Observe the given amount.
-  void Observe(double value);
+  void Observe(double value, const bool& alert = true);
 
   /// \brief Get the current value of the summary.
   ///
   /// Collect is called by the Registry when collecting metrics.
   ClientMetric Collect();
-  void UpdateRetentionTime(const double& retention_time, const bool& bump = true);
-
-  /// \brief Check if the metric has expired
-  bool Expired() const;
 
  private:
   const Quantiles quantiles_;
@@ -95,8 +92,6 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
   std::uint64_t count_;
   double sum_;
   detail::TimeWindowQuantiles quantile_values_;
-  std::atomic<double> retention_time_{1e9};
-  std::atomic<std::time_t> last_update_{std::time(nullptr)};
 };
 
 /// \brief Return a builder to configure and register a Summary metric.

--- a/core/src/counter.cc
+++ b/core/src/counter.cc
@@ -2,9 +2,15 @@
 
 namespace prometheus {
 
-void Counter::Increment() { gauge_.Increment(); }
+void Counter::Increment() {
+  gauge_.Increment(); 
+  last_update_.store(std::time(nullptr));
+}
 
-void Counter::Increment(const double val) { gauge_.Increment(val); }
+void Counter::Increment(const double val) {
+  gauge_.Increment(val);
+  last_update_.store(std::time(nullptr));
+}
 
 double Counter::Value() const { return gauge_.Value(); }
 
@@ -14,8 +20,13 @@ ClientMetric Counter::Collect() const {
   return metric;
 }
 
-bool Counter::Expired(const std::time_t& time, const double& seconds) const {
-  return false;
+void Counter::UpdateRetentionTime(const double& retention_time, const bool& bump) {
+  if (bump) last_update_.store(std::time(nullptr));
+  retention_time_ = retention_time; 
+};
+
+bool Counter::Expired() const {
+  return std::difftime(std::time(nullptr), last_update_) > retention_time_;
 }
 
 }  // namespace prometheus

--- a/core/src/counter.cc
+++ b/core/src/counter.cc
@@ -2,31 +2,19 @@
 
 namespace prometheus {
 
-void Counter::Increment() {
-  gauge_.Increment(); 
-  last_update_.store(std::time(nullptr));
+void Counter::Increment(const double& value, const bool& alert) {
+  if (value < 0.0) return;
+  value_ = value_ + value;
+  last_update_ = std::time(nullptr);
+  if (alert) AlertIfNoFamily();
 }
 
-void Counter::Increment(const double val) {
-  gauge_.Increment(val);
-  last_update_.store(std::time(nullptr));
-}
-
-double Counter::Value() const { return gauge_.Value(); }
+double Counter::Value() const { return value_; }
 
 ClientMetric Counter::Collect() const {
   ClientMetric metric;
   metric.counter.value = Value();
   return metric;
-}
-
-void Counter::UpdateRetentionTime(const double& retention_time, const bool& bump) {
-  if (bump) last_update_.store(std::time(nullptr));
-  retention_time_ = retention_time; 
-};
-
-bool Counter::Expired() const {
-  return std::difftime(std::time(nullptr), last_update_) > retention_time_;
 }
 
 }  // namespace prometheus

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -11,8 +11,13 @@ namespace prometheus {
 namespace detail {
 
 template <typename T>
-Builder<T>& Builder<T>::Labels(
-    const std::map<std::string, std::string>& labels) {
+Builder<T>& Builder<T>::RetentionBehavior(const prometheus::RetentionBehavior& retention_behavior) {
+  retention_behavior_ = retention_behavior;
+  return *this;
+}
+
+template <typename T>
+Builder<T>& Builder<T>::Labels(const std::map<std::string, std::string>& labels) {
   labels_ = labels;
   return *this;
 }

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -30,14 +30,8 @@ Builder<T>& Builder<T>::Help(const std::string& help) {
 }
 
 template <typename T>
-Builder<T>& Builder<T>::Seconds(const double& seconds) {
-  seconds_ = seconds;
-  return *this;
-}
-
-template <typename T>
 Family<T>& Builder<T>::Register(Registry& registry) {
-  return registry.Add<T>(name_, help_, labels_, seconds_);
+  return registry.Add<T>(name_, help_, labels_);
 }
 
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Counter>;

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -30,7 +30,7 @@ Builder<T>& Builder<T>::Help(const std::string& help) {
 }
 
 template <typename T>
-Family<T>& Builder<T>::Register(Registry& registry) {
+std::shared_ptr<Family<T>> Builder<T>::Register(Registry& registry) {
   return registry.Add<T>(name_, help_, labels_);
 }
 

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -36,7 +36,7 @@ Builder<T>& Builder<T>::Help(const std::string& help) {
 
 template <typename T>
 std::shared_ptr<Family<T>> Builder<T>::Register(Registry& registry) {
-  return registry.Add<T>(name_, help_, labels_);
+  return registry.Add<T>(name_, help_, labels_, retention_behavior_);
 }
 
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Counter>;

--- a/core/src/family.cc
+++ b/core/src/family.cc
@@ -43,6 +43,7 @@ std::shared_ptr<T> Family<T>::Add(const std::map<std::string, std::string>& labe
     assert(metric.second);
     labels_.insert({hash, labels});
     labels_reverse_lookup_.insert({metric.first->second, hash});
+    object->has_family_ = true;
     return metric.first->second;
   }
 }
@@ -58,6 +59,7 @@ void Family<T>::Remove(std::shared_ptr<T> metric) {
   metrics_.erase(hash);
   labels_.erase(hash);
   labels_reverse_lookup_.erase(metric);
+  metric->has_family_ = false;
 }
 
 template <typename T>

--- a/core/src/gauge.cc
+++ b/core/src/gauge.cc
@@ -1,62 +1,43 @@
 #include "prometheus/gauge.h"
 
+#include <atomic>
 #include <ctime>
 
 namespace prometheus {
 
 Gauge::Gauge(const double& value) : value_(value) {}
 
-void Gauge::Increment() { Increment(1.0); }
-
-void Gauge::Increment(const double value) {
-  if (value < 0.0) {
-    return;
-  }
-  Change(value);
+void Gauge::Increment(const double& value, const bool& alert) {
+  if (value < 0.0) return;
+  value_ = value_ + value;
+  last_update_ = std::time(nullptr);
+  if (alert) AlertIfNoFamily();
 }
 
-void Gauge::Decrement() { Decrement(1.0); }
-
-void Gauge::Decrement(const double value) {
-  if (value < 0.0) {
-    return;
-  }
-  Change(-1.0 * value);
+void Gauge::Decrement(const double& value, const bool& alert) {
+  if (value < 0.0) return;
+  value_ = value_ - value;
+  last_update_ = std::time(nullptr);
+  if (alert) AlertIfNoFamily();
 }
 
-void Gauge::Set(const double value) {
-  value_.store(value);
-  last_update_.store(std::time(nullptr));
-}
-
-void Gauge::Change(const double value) {
-  auto current = value_.load();
-  while (!value_.compare_exchange_weak(current, current + value))
-    ;
-  last_update_.store(std::time(nullptr));
+void Gauge::Set(const double& value, const bool& alert) {
+  value_ = value;
+  last_update_ = std::time(nullptr);
+  if (alert) AlertIfNoFamily();
 }
 
 void Gauge::SetToCurrentTime() {
   const auto time = std::time(nullptr);
   Set(static_cast<double>(time));
-  last_update_.store(std::time(nullptr));
 }
 
 double Gauge::Value() const { return value_; }
 
 ClientMetric Gauge::Collect() const {
   ClientMetric metric;
-  metric.gauge.value = Value();
+  metric.gauge.value = value_;
   return metric;
-}
-
-void Gauge::UpdateRetentionTime(const double& retention_time, const bool& bump) {
-  if (bump) last_update_.store(std::time(nullptr));
-  retention_time_ = retention_time; 
-};
-
-bool Gauge::Expired() const {
-  return std::difftime(std::time(nullptr), last_update_) > retention_time_;
 }
 
 }  // namespace prometheus

--- a/core/src/gauge.cc
+++ b/core/src/gauge.cc
@@ -4,7 +4,7 @@
 
 namespace prometheus {
 
-Gauge::Gauge(const double value) : value_{value} {}
+Gauge::Gauge(const double& value) : value_(value) {}
 
 void Gauge::Increment() { Increment(1.0); }
 
@@ -26,19 +26,20 @@ void Gauge::Decrement(const double value) {
 
 void Gauge::Set(const double value) {
   value_.store(value);
-  time_.store(std::time(nullptr));
+  last_update_.store(std::time(nullptr));
 }
 
 void Gauge::Change(const double value) {
   auto current = value_.load();
   while (!value_.compare_exchange_weak(current, current + value))
     ;
-  time_.store(std::time(nullptr));
+  last_update_.store(std::time(nullptr));
 }
 
 void Gauge::SetToCurrentTime() {
   const auto time = std::time(nullptr);
   Set(static_cast<double>(time));
+  last_update_.store(std::time(nullptr));
 }
 
 double Gauge::Value() const { return value_; }
@@ -49,8 +50,13 @@ ClientMetric Gauge::Collect() const {
   return metric;
 }
 
-bool Gauge::Expired(const std::time_t& time, const double& seconds) const {
-  return std::difftime(time, time_) > seconds;
+void Gauge::UpdateRetentionTime(const double& retention_time, const bool& bump) {
+  if (bump) last_update_.store(std::time(nullptr));
+  retention_time_ = retention_time; 
+};
+
+bool Gauge::Expired() const {
+  return std::difftime(std::time(nullptr), last_update_) > retention_time_;
 }
 
 }  // namespace prometheus

--- a/core/src/metric_base.cc
+++ b/core/src/metric_base.cc
@@ -1,0 +1,23 @@
+#include "prometheus/metric_base.h"
+
+#include <ctime>
+#include <iostream>
+
+namespace prometheus {
+
+bool MetricBase::HasFamily() { return has_family_; }
+
+void MetricBase::AlertIfNoFamily() {
+  if (!has_family_) std::cerr << "prometheus-cpp:: This metric has no family" << std::endl;
+}
+
+void MetricBase::UpdateRetentionTime(const double& retention_time, const bool& bump) {
+  if (bump) last_update_.store(std::time(nullptr));
+  retention_time_.store(retention_time);
+};
+
+bool MetricBase::Expired() const {
+  return std::difftime(std::time(nullptr), last_update_.load()) > retention_time_.load();
+}
+
+}  // namespace prometheus

--- a/core/src/metric_base.cc
+++ b/core/src/metric_base.cc
@@ -17,7 +17,7 @@ void MetricBase::UpdateRetentionTime(const double& retention_time, const bool& b
 };
 
 bool MetricBase::Expired() const {
-  return std::difftime(std::time(nullptr), last_update_.load()) > retention_time_.load();
+  return std::difftime(std::time(nullptr), last_update_) > retention_time_;
 }
 
 }  // namespace prometheus

--- a/core/src/registry.cc
+++ b/core/src/registry.cc
@@ -33,7 +33,7 @@ bool FamilyNameExists(const std::string& name, const T& families,
 }
 }  // namespace
 
-Registry::Registry(InsertBehavior insert_behavior) : insert_behavior_{insert_behavior} {}
+Registry::Registry(const InsertBehavior& insert_behavior) : insert_behavior_{insert_behavior} {}
 
 Registry::~Registry() = default;
 
@@ -90,8 +90,10 @@ bool Registry::NameExistsInOtherType<Summary>(const std::string& name) const {
 }
 
 template <typename T>
-std::shared_ptr<Family<T>> Registry::Add(const std::string& name, const std::string& help, 
-                         const std::map<std::string, std::string>& labels) {
+std::shared_ptr<Family<T>> Registry::Add(
+                         const std::string& name, const std::string& help, 
+                         const std::map<std::string, std::string>& labels,
+                         const RetentionBehavior& retention_behavior) {
   std::lock_guard<std::mutex> lock{mutex_};
 
   if (NameExistsInOtherType<T>(name)) {
@@ -125,7 +127,7 @@ std::shared_ptr<Family<T>> Registry::Add(const std::string& name, const std::str
     }
   }
 
-  auto family = std::make_shared<Family<T>>(name, help, labels);
+  auto family = std::make_shared<Family<T>>(name, help, labels, retention_behavior);
   families.push_back(family);
   return family;
 }
@@ -157,18 +159,22 @@ bool Registry::UpdateRetentionTime(const double& retention_time, const std::stri
 
 template std::shared_ptr<Family<Counter>> Registry::Add(
     const std::string& name, const std::string& help,
-    const std::map<std::string, std::string>& labels);
+    const std::map<std::string, std::string>& labels,
+    const RetentionBehavior& retention_behavior);
 
 template std::shared_ptr<Family<Gauge>> Registry::Add(
     const std::string& name, const std::string& help,
-    const std::map<std::string, std::string>& labels);
+    const std::map<std::string, std::string>& labels,
+    const RetentionBehavior& retention_behavior);
 
 template std::shared_ptr<Family<Summary>> Registry::Add(
     const std::string& name, const std::string& help,
-    const std::map<std::string, std::string>& labels);
+    const std::map<std::string, std::string>& labels,
+    const RetentionBehavior& retention_behavior);
 
 template std::shared_ptr<Family<Histogram>> Registry::Add(
     const std::string& name, const std::string& help,
-    const std::map<std::string, std::string>& labels);
+    const std::map<std::string, std::string>& labels,
+    const RetentionBehavior& retention_behavior);
 
 }  // namespace prometheus

--- a/core/tests/builder_test.cc
+++ b/core/tests/builder_test.cc
@@ -49,45 +49,45 @@ class BuilderTest : public testing::Test {
 };
 
 TEST_F(BuilderTest, build_counter) {
-  auto& family = BuildCounter()
+  auto family = BuildCounter()
                      .Name(name)
                      .Help(help)
                      .Labels(const_labels)
                      .Register(registry);
-  family.Add(more_labels);
+  family->Add(more_labels);
 
   verifyCollectedLabels();
 }
 
 TEST_F(BuilderTest, build_gauge) {
-  auto& family = BuildGauge()
+  auto family = BuildGauge()
                      .Name(name)
                      .Help(help)
                      .Labels(const_labels)
                      .Register(registry);
-  family.Add(more_labels);
+  family->Add(more_labels);
 
   verifyCollectedLabels();
 }
 
 TEST_F(BuilderTest, build_histogram) {
-  auto& family = BuildHistogram()
+  auto family = BuildHistogram()
                      .Name(name)
                      .Help(help)
                      .Labels(const_labels)
                      .Register(registry);
-  family.Add(more_labels, Histogram::BucketBoundaries{1, 2});
+  family->Add(more_labels, Histogram::BucketBoundaries{1, 2});
 
   verifyCollectedLabels();
 }
 
 TEST_F(BuilderTest, build_summary) {
-  auto& family = BuildSummary()
+  auto family = BuildSummary()
                      .Name(name)
                      .Help(help)
                      .Labels(const_labels)
                      .Register(registry);
-  family.Add(more_labels, Summary::Quantiles{});
+  family->Add(more_labels, Summary::Quantiles{});
 
   verifyCollectedLabels();
 }

--- a/core/tests/counter_test.cc
+++ b/core/tests/counter_test.cc
@@ -12,28 +12,28 @@ TEST(CounterTest, initialize_with_zero) {
 
 TEST(CounterTest, inc) {
   Counter counter;
-  counter.Increment();
+  counter.Increment(1, false);
   EXPECT_EQ(counter.Value(), 1.0);
 }
 
 TEST(CounterTest, inc_number) {
   Counter counter;
-  counter.Increment(4);
+  counter.Increment(4, false);
   EXPECT_EQ(counter.Value(), 4.0);
 }
 
 TEST(CounterTest, inc_multiple) {
   Counter counter;
-  counter.Increment();
-  counter.Increment();
-  counter.Increment(5);
+  counter.Increment(1, false);
+  counter.Increment(1, false);
+  counter.Increment(5, false);
   EXPECT_EQ(counter.Value(), 7.0);
 }
 
 TEST(CounterTest, inc_negative_value) {
   Counter counter;
-  counter.Increment(5.0);
-  counter.Increment(-5.0);
+  counter.Increment(5.0, false);
+  counter.Increment(-5.0, false);
   EXPECT_EQ(counter.Value(), 5.0);
 }
 

--- a/core/tests/family_test.cc
+++ b/core/tests/family_test.cc
@@ -18,8 +18,7 @@ TEST(FamilyTest, labels) {
 
   Family<Counter> family{"total_requests",
                          "Counts all requests",
-                         {{const_label.name, const_label.value}},
-                         std::numeric_limits<double>::max()};
+                         {{const_label.name, const_label.value}}};
   family.Add({{dynamic_label.name, dynamic_label.value}});
   auto collected = family.Collect();
   ASSERT_GE(collected.size(), 1U);
@@ -29,8 +28,7 @@ TEST(FamilyTest, labels) {
 }
 
 TEST(FamilyTest, counter_value) {
-  Family<Counter> family{"total_requests", "Counts all requests", {},
-                         std::numeric_limits<double>::max()};
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
   auto& counter = family.Add({});
   counter.Increment();
   auto collected = family.Collect();
@@ -40,8 +38,7 @@ TEST(FamilyTest, counter_value) {
 }
 
 TEST(FamilyTest, remove) {
-  Family<Counter> family{"total_requests", "Counts all requests", {},
-                         std::numeric_limits<double>::max()};
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
   auto& counter1 = family.Add({{"name", "counter1"}});
   family.Add({{"name", "counter2"}});
   family.Remove(&counter1);
@@ -56,8 +53,7 @@ TEST(FamilyTest, removeUnknownMetricMustNotCrash) {
 }
 
 TEST(FamilyTest, Histogram) {
-  Family<Histogram> family{"request_latency", "Latency Histogram", {},
-                           std::numeric_limits<double>::max()};
+  Family<Histogram> family{"request_latency", "Latency Histogram", {}};
   auto& histogram1 = family.Add({{"name", "histogram1"}},
                                 Histogram::BucketBoundaries{0, 1, 2});
   histogram1.Observe(0);
@@ -68,8 +64,7 @@ TEST(FamilyTest, Histogram) {
 }
 
 TEST(FamilyTest, add_twice) {
-  Family<Counter> family{"total_requests", "Counts all requests", {},
-                         std::numeric_limits<double>::max()};
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
   auto& counter = family.Add({{"name", "counter1"}});
   auto& counter1 = family.Add({{"name", "counter1"}});
   ASSERT_EQ(&counter, &counter1);
@@ -78,16 +73,14 @@ TEST(FamilyTest, add_twice) {
 TEST(FamilyTest, should_assert_on_invalid_metric_name) {
   auto create_family_with_invalid_name = []() {
     return detail::make_unique<Family<Counter>>(
-        "", "empty name", std::map<std::string, std::string>{},
-        std::numeric_limits<double>::max());
+        "", "empty name", std::map<std::string, std::string>{});
   };
   EXPECT_DEBUG_DEATH(create_family_with_invalid_name(),
                      ".*Assertion .*CheckMetricName.*");
 }
 
 TEST(FamilyTest, should_assert_on_invalid_labels) {
-  Family<Counter> family{"total_requests", "Counts all requests", {},
-                         std::numeric_limits<double>::max()};
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
   auto add_metric_with_invalid_label_name = [&family]() {
     family.Add({{"__invalid", "counter1"}});
   };

--- a/core/tests/family_test.cc
+++ b/core/tests/family_test.cc
@@ -29,8 +29,8 @@ TEST(FamilyTest, labels) {
 
 TEST(FamilyTest, counter_value) {
   Family<Counter> family{"total_requests", "Counts all requests", {}};
-  auto& counter = family.Add({});
-  counter.Increment();
+  auto counter = family.Add({});
+  counter->Increment();
   auto collected = family.Collect();
   ASSERT_GE(collected.size(), 1U);
   ASSERT_GE(collected[0].metric.size(), 1U);
@@ -39,9 +39,9 @@ TEST(FamilyTest, counter_value) {
 
 TEST(FamilyTest, remove) {
   Family<Counter> family{"total_requests", "Counts all requests", {}};
-  auto& counter1 = family.Add({{"name", "counter1"}});
+  auto counter1 = family.Add({{"name", "counter1"}});
   family.Add({{"name", "counter2"}});
-  family.Remove(&counter1);
+  family.Remove(counter1);
   auto collected = family.Collect();
   ASSERT_GE(collected.size(), 1U);
   EXPECT_EQ(collected[0].metric.size(), 1U);
@@ -54,9 +54,9 @@ TEST(FamilyTest, removeUnknownMetricMustNotCrash) {
 
 TEST(FamilyTest, Histogram) {
   Family<Histogram> family{"request_latency", "Latency Histogram", {}};
-  auto& histogram1 = family.Add({{"name", "histogram1"}},
+  auto histogram1 = family.Add({{"name", "histogram1"}},
                                 Histogram::BucketBoundaries{0, 1, 2});
-  histogram1.Observe(0);
+  histogram1->Observe(0);
   auto collected = family.Collect();
   ASSERT_EQ(collected.size(), 1U);
   ASSERT_GE(collected[0].metric.size(), 1U);
@@ -65,9 +65,9 @@ TEST(FamilyTest, Histogram) {
 
 TEST(FamilyTest, add_twice) {
   Family<Counter> family{"total_requests", "Counts all requests", {}};
-  auto& counter = family.Add({{"name", "counter1"}});
-  auto& counter1 = family.Add({{"name", "counter1"}});
-  ASSERT_EQ(&counter, &counter1);
+  auto counter = family.Add({{"name", "counter1"}});
+  auto counter1 = family.Add({{"name", "counter1"}});
+  ASSERT_EQ(counter, counter1);
 }
 
 TEST(FamilyTest, should_assert_on_invalid_metric_name) {

--- a/core/tests/gauge_test.cc
+++ b/core/tests/gauge_test.cc
@@ -72,11 +72,5 @@ TEST(GaugeTest, set_multiple) {
   EXPECT_EQ(gauge.Value(), 1.0);
 }
 
-TEST(GaugeTest, set_to_current_time) {
-  Gauge gauge;
-  gauge.SetToCurrentTime();
-  EXPECT_GT(gauge.Value(), 0.0);
-}
-
 }  // namespace
 }  // namespace prometheus

--- a/core/tests/gauge_test.cc
+++ b/core/tests/gauge_test.cc
@@ -12,63 +12,63 @@ TEST(GaugeTest, initialize_with_zero) {
 
 TEST(GaugeTest, inc) {
   Gauge gauge;
-  gauge.Increment();
+  gauge.Increment(1, false);
   EXPECT_EQ(gauge.Value(), 1.0);
 }
 
 TEST(GaugeTest, inc_number) {
   Gauge gauge;
-  gauge.Increment(4);
+  gauge.Increment(4, false);
   EXPECT_EQ(gauge.Value(), 4.0);
 }
 
 TEST(GaugeTest, inc_multiple) {
   Gauge gauge;
-  gauge.Increment();
-  gauge.Increment();
-  gauge.Increment(5);
+  gauge.Increment(1, false);
+  gauge.Increment(1, false);
+  gauge.Increment(5, false);
   EXPECT_EQ(gauge.Value(), 7.0);
 }
 
 TEST(GaugeTest, inc_negative_value) {
   Gauge gauge;
-  gauge.Increment(5.0);
-  gauge.Increment(-5.0);
+  gauge.Increment(5.0, false);
+  gauge.Increment(-5.0, false);
   EXPECT_EQ(gauge.Value(), 5.0);
 }
 
 TEST(GaugeTest, dec) {
   Gauge gauge;
-  gauge.Set(5.0);
-  gauge.Decrement();
+  gauge.Set(5.0, false);
+  gauge.Decrement(1, false);
   EXPECT_EQ(gauge.Value(), 4.0);
 }
 
 TEST(GaugeTest, dec_negative_value) {
   Gauge gauge;
-  gauge.Set(5.0);
-  gauge.Decrement(-1.0);
+  gauge.Set(5.0, false);
+  gauge.Decrement(-1.0, false);
   EXPECT_EQ(gauge.Value(), 5.0);
 }
 
 TEST(GaugeTest, dec_number) {
   Gauge gauge;
-  gauge.Set(5.0);
-  gauge.Decrement(3.0);
+  gauge.Set(5.0, false);
+  gauge.Decrement(3.0, false);
   EXPECT_EQ(gauge.Value(), 2.0);
 }
 
 TEST(GaugeTest, set) {
   Gauge gauge;
-  gauge.Set(3.0);
+  gauge.Set(3.0, false);
   EXPECT_EQ(gauge.Value(), 3.0);
 }
 
 TEST(GaugeTest, set_multiple) {
   Gauge gauge;
-  gauge.Set(3.0);
-  gauge.Set(8.0);
-  gauge.Set(1.0);
+  gauge.Set(3.0, false);
+  gauge.Set(8.0, false);
+  gauge.Set(1.0, false);
   EXPECT_EQ(gauge.Value(), 1.0);
 }
 

--- a/core/tests/histogram_test.cc
+++ b/core/tests/histogram_test.cc
@@ -17,8 +17,8 @@ TEST(HistogramTest, initialize_with_zero) {
 
 TEST(HistogramTest, sample_count) {
   Histogram histogram{{1}};
-  histogram.Observe(0);
-  histogram.Observe(200);
+  histogram.Observe(0, false);
+  histogram.Observe(200, false);
   auto metric = histogram.Collect();
   auto h = metric.histogram;
   EXPECT_EQ(h.sample_count, 2U);
@@ -26,9 +26,9 @@ TEST(HistogramTest, sample_count) {
 
 TEST(HistogramTest, sample_sum) {
   Histogram histogram{{1}};
-  histogram.Observe(0);
-  histogram.Observe(1);
-  histogram.Observe(101);
+  histogram.Observe(0, false);
+  histogram.Observe(1, false);
+  histogram.Observe(101, false);
   auto metric = histogram.Collect();
   auto h = metric.histogram;
   EXPECT_EQ(h.sample_sum, 102);
@@ -53,9 +53,9 @@ TEST(HistogramTest, bucket_bounds) {
 
 TEST(HistogramTest, bucket_counts_not_reset_by_collection) {
   Histogram histogram{{1, 2}};
-  histogram.Observe(1.5);
+  histogram.Observe(1.5, false);
   histogram.Collect();
-  histogram.Observe(1.5);
+  histogram.Observe(1.5, false);
   auto metric = histogram.Collect();
   auto h = metric.histogram;
   ASSERT_EQ(h.bucket.size(), 3U);
@@ -64,13 +64,13 @@ TEST(HistogramTest, bucket_counts_not_reset_by_collection) {
 
 TEST(HistogramTest, cumulative_bucket_count) {
   Histogram histogram{{1, 2}};
-  histogram.Observe(0);
-  histogram.Observe(0.5);
-  histogram.Observe(1);
-  histogram.Observe(1.5);
-  histogram.Observe(1.5);
-  histogram.Observe(2);
-  histogram.Observe(3);
+  histogram.Observe(0, false);
+  histogram.Observe(0.5, false);
+  histogram.Observe(1, false);
+  histogram.Observe(1.5, false);
+  histogram.Observe(1.5, false);
+  histogram.Observe(2, false);
+  histogram.Observe(3, false);
   auto metric = histogram.Collect();
   auto h = metric.histogram;
   ASSERT_EQ(h.bucket.size(), 3U);
@@ -81,8 +81,8 @@ TEST(HistogramTest, cumulative_bucket_count) {
 
 TEST(HistogramTest, observe_multiple_test_bucket_counts) {
   Histogram histogram{{1, 2}};
-  histogram.ObserveMultiple({5, 9, 3}, 20);
-  histogram.ObserveMultiple({0, 20, 6}, 34);
+  histogram.ObserveMultiple({5, 9, 3}, 20, false);
+  histogram.ObserveMultiple({0, 20, 6}, 34, false);
   auto metric = histogram.Collect();
   auto h = metric.histogram;
   ASSERT_EQ(h.bucket.size(), 3U);
@@ -93,8 +93,8 @@ TEST(HistogramTest, observe_multiple_test_bucket_counts) {
 
 TEST(HistogramTest, observe_multiple_test_total_sum) {
   Histogram histogram{{1, 2}};
-  histogram.ObserveMultiple({5, 9, 3}, 20);
-  histogram.ObserveMultiple({0, 20, 6}, 34);
+  histogram.ObserveMultiple({5, 9, 3}, 20, false);
+  histogram.ObserveMultiple({0, 20, 6}, 34, false);
   auto metric = histogram.Collect();
   auto h = metric.histogram;
   EXPECT_EQ(h.sample_count, 43U);
@@ -105,7 +105,7 @@ TEST(HistogramTest, observe_multiple_test_length_error) {
   Histogram histogram{{1, 2}};
   // 2 bucket boundaries means there are 3 buckets, so giving just 2 bucket
   // increments should result in a length_error.
-  ASSERT_THROW(histogram.ObserveMultiple({5, 9}, 20), std::length_error);
+  ASSERT_THROW(histogram.ObserveMultiple({5, 9}, 20, false), std::length_error);
 }
 
 }  // namespace

--- a/core/tests/registry_test.cc
+++ b/core/tests/registry_test.cc
@@ -12,10 +12,10 @@ namespace {
 
 TEST(RegistryTest, collect_single_metric_family) {
   Registry registry{};
-  auto& counter_family =
+  auto counter_family =
       BuildCounter().Name("test").Help("a test").Register(registry);
-  counter_family.Add({{"name", "counter1"}});
-  counter_family.Add({{"name", "counter2"}});
+  counter_family->Add({{"name", "counter1"}});
+  counter_family->Add({{"name", "counter2"}});
   auto collected = registry.Collect();
   ASSERT_EQ(collected.size(), 1U);
   EXPECT_EQ(collected[0].name, "test");
@@ -29,11 +29,11 @@ TEST(RegistryTest, collect_single_metric_family) {
 
 TEST(RegistryTest, build_histogram_family) {
   Registry registry{};
-  auto& histogram_family =
+  auto histogram_family =
       BuildHistogram().Name("hist").Help("Test Histogram").Register(registry);
-  auto& histogram = histogram_family.Add({{"name", "test_histogram_1"}},
+  auto histogram = histogram_family->Add({{"name", "test_histogram_1"}},
                                          Histogram::BucketBoundaries{0, 1, 2});
-  histogram.Observe(1.1);
+  histogram->Observe(1.1);
   auto collected = registry.Collect();
   ASSERT_EQ(collected.size(), 1U);
 }
@@ -88,7 +88,7 @@ TEST(RegistryTest, append_same_families) {
         .Name("counter")
         .Help("Test Counter")
         .Register(registry)
-        .Add({{"name", "test_counter"}});
+        ->Add({{"name", "test_counter"}});
   }
 
   auto collected = registry.Collect();
@@ -113,7 +113,7 @@ TEST(RegistryTest, merge_same_families) {
         .Name("counter")
         .Help("Test Counter")
         .Register(registry)
-        .Add({{"name", "test_counter"}});
+        ->Add({{"name", "test_counter"}});
   }
 
   auto collected = registry.Collect();

--- a/core/tests/serializer_test.cc
+++ b/core/tests/serializer_test.cc
@@ -13,8 +13,8 @@ class SerializerTest : public testing::Test {
  public:
   void SetUp() override {
     Family<Counter> family{"requests_total", "", {}};
-    auto& counter = family.Add({});
-    counter.Increment();
+    auto counter = family.Add({});
+    counter->Increment();
 
     collected = family.Collect();
   }

--- a/core/tests/summary_test.cc
+++ b/core/tests/summary_test.cc
@@ -18,8 +18,8 @@ TEST(SummaryTest, initialize_with_zero) {
 
 TEST(SummaryTest, sample_count) {
   Summary summary{Summary::Quantiles{{0.5, 0.05}}};
-  summary.Observe(0);
-  summary.Observe(200);
+  summary.Observe(0, false);
+  summary.Observe(200, false);
   auto metric = summary.Collect();
   auto s = metric.summary;
   EXPECT_EQ(s.sample_count, 2U);
@@ -27,9 +27,9 @@ TEST(SummaryTest, sample_count) {
 
 TEST(SummaryTest, sample_sum) {
   Summary summary{Summary::Quantiles{{0.5, 0.05}}};
-  summary.Observe(0);
-  summary.Observe(1);
-  summary.Observe(101);
+  summary.Observe(0, false);
+  summary.Observe(1, false);
+  summary.Observe(101, false);
   auto metric = summary.Collect();
   auto s = metric.summary;
   EXPECT_EQ(s.sample_sum, 102);
@@ -56,7 +56,7 @@ TEST(SummaryTest, quantile_values) {
   static const int SAMPLES = 1000000;
 
   Summary summary{Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}}};
-  for (int i = 1; i <= SAMPLES; ++i) summary.Observe(i);
+  for (int i = 1; i <= SAMPLES; ++i) summary.Observe(i, false);
 
   auto metric = summary.Collect();
   auto s = metric.summary;
@@ -70,7 +70,7 @@ TEST(SummaryTest, quantile_values) {
 TEST(SummaryTest, max_age) {
   Summary summary{Summary::Quantiles{{0.99, 0.001}}, std::chrono::seconds(1),
                   2};
-  summary.Observe(8.0);
+  summary.Observe(8.0, false);
 
   static const auto test_value = [&summary](double ref) {
     auto metric = summary.Collect();

--- a/core/tests/text_serializer_test.cc
+++ b/core/tests/text_serializer_test.cc
@@ -92,8 +92,8 @@ TEST_F(TextSerializerTest, shouldSerializeHistogramWithNoBuckets) {
 
 TEST_F(TextSerializerTest, shouldSerializeHistogram) {
   Histogram histogram{{1}};
-  histogram.Observe(0);
-  histogram.Observe(200);
+  histogram.Observe(0, false);
+  histogram.Observe(200, false);
   metric = histogram.Collect();
 
   const auto serialized = Serialize(MetricType::Histogram);
@@ -106,8 +106,8 @@ TEST_F(TextSerializerTest, shouldSerializeHistogram) {
 
 TEST_F(TextSerializerTest, shouldSerializeSummary) {
   Summary summary{Summary::Quantiles{{0.5, 0.05}}};
-  summary.Observe(0);
-  summary.Observe(200);
+  summary.Observe(0, false);
+  summary.Observe(200, false);
   metric = summary.Collect();
 
   const auto serialized = Serialize(MetricType::Summary);

--- a/pull/src/handler.cc
+++ b/pull/src/handler.cc
@@ -24,18 +24,18 @@ MetricsHandler::MetricsHandler(
               .Name("exposer_transferred_bytes_total")
               .Help("Transferred bytes to metrics services")
               .Register(registry)),
-      bytes_transferred_(bytes_transferred_family_.Add({})),
+      bytes_transferred_(bytes_transferred_family_->Add({})),
       num_scrapes_family_(BuildCounter()
                               .Name("exposer_scrapes_total")
                               .Help("Number of times metrics were scraped")
                               .Register(registry)),
-      num_scrapes_(num_scrapes_family_.Add({})),
+      num_scrapes_(num_scrapes_family_->Add({})),
       request_latencies_family_(
           BuildSummary()
               .Name("exposer_request_latencies")
               .Help("Latencies of serving scrape requests, in microseconds")
               .Register(registry)),
-      request_latencies_(request_latencies_family_.Add(
+      request_latencies_(request_latencies_family_->Add(
           {}, Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}})) {}
 
 #ifdef HAVE_ZLIB
@@ -127,10 +127,10 @@ bool MetricsHandler::handleGet(CivetServer*, struct mg_connection* conn) {
   auto stop_time_of_request = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
       stop_time_of_request - start_time_of_request);
-  request_latencies_.Observe(duration.count());
+  request_latencies_->Observe(duration.count());
 
-  bytes_transferred_.Increment(bodySize);
-  num_scrapes_.Increment();
+  bytes_transferred_->Increment(bodySize);
+  num_scrapes_->Increment();
   return true;
 }
 std::vector<MetricFamily> MetricsHandler::CollectMetrics() const {

--- a/pull/src/handler.h
+++ b/pull/src/handler.h
@@ -21,12 +21,12 @@ class MetricsHandler : public CivetHandler {
   std::vector<MetricFamily> CollectMetrics() const;
 
   const std::vector<std::weak_ptr<Collectable>>& collectables_;
-  Family<Counter>& bytes_transferred_family_;
-  Counter& bytes_transferred_;
-  Family<Counter>& num_scrapes_family_;
-  Counter& num_scrapes_;
-  Family<Summary>& request_latencies_family_;
-  Summary& request_latencies_;
+  std::shared_ptr<Family<Counter>> bytes_transferred_family_;
+  std::shared_ptr<Counter> bytes_transferred_;
+  std::shared_ptr<Family<Counter>> num_scrapes_family_;
+  std::shared_ptr<Counter> num_scrapes_;
+  std::shared_ptr<Family<Summary>> request_latencies_family_;
+  std::shared_ptr<Summary> request_latencies_;
 };
 }  // namespace detail
 }  // namespace prometheus

--- a/pull/tests/integration/sample_server.cc
+++ b/pull/tests/integration/sample_server.cc
@@ -20,14 +20,14 @@ int main() {
 
   // add a new counter family to the registry (families combine values with the
   // same name, but distinct label dimensions)
-  auto& counter_family = BuildCounter()
+  auto counter_family = BuildCounter()
                              .Name("time_running_seconds_total")
                              .Help("How many seconds is this server running?")
                              .Labels({{"label", "value"}})
                              .Register(*registry);
 
   // add a counter to the metric family
-  auto& second_counter = counter_family.Add(
+  auto second_counter = counter_family->Add(
       {{"another_label", "value"}, {"yet_another_label", "value"}});
 
   // ask the exposer to scrape the registry on incoming scrapes
@@ -36,7 +36,7 @@ int main() {
   for (;;) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     // increment the counter by one (second)
-    second_counter.Increment();
+    second_counter->Increment();
   }
   return 0;
 }

--- a/push/tests/integration/sample_client.cc
+++ b/push/tests/integration/sample_client.cc
@@ -39,14 +39,14 @@ int main() {
 
   // add a new counter family to the registry (families combine values with the
   // same name, but distinct label dimensions)
-  auto& counter_family = BuildCounter()
+  auto counter_family = BuildCounter()
                              .Name("time_running_seconds_total")
                              .Help("How many seconds is this server running?")
                              .Labels({{"label", "value"}})
                              .Register(*registry);
 
   // add a counter to the metric family
-  auto& second_counter = counter_family.Add(
+  auto second_counter = counter_family->Add(
       {{"another_label", "value"}, {"yet_another_label", "value"}});
 
   // ask the pusher to push the metrics to the pushgateway
@@ -55,7 +55,7 @@ int main() {
   for (;;) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     // increment the counter by one (second)
-    second_counter.Increment();
+    second_counter->Increment();
 
     // push metrics
     auto returnCode = gateway.Push();


### PR DESCRIPTION
The prometheus-cpp lib provides functionality to expose internal data to Prometheus via a series of sockets (unique to each node). Typically, each metric will get exposed for the lifetime of the process (node). Thus, if a node created 1000 metrics at the beginning of the program and never updated them again for the entire process, prometheus-cpp would continue exposing them to the socket for the entire process (similar to a while loop with 1000 print lines).

Additionally, prometheus-cpp uses a number of return by references, which poses the following issue:
```
auto& family = BuildCounter()....
auto& metric = family.Add(labels);
family.Remove(metric);
metric.Increment(); // Segfault

```
This can be fixed by returning a shared pointer instead. However, the nuance to this is that a shared pointer that has been removed may update its data but that data will not get exposed.