### PR TITLE
Fix coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,4 +22,5 @@ jobs:
       - name: Test
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_GIT_BRANCH: "${{ github.ref }}"
         run: .github/scripts/run-cmake-coverage


### PR DESCRIPTION
Looks like according to https://github.com/nickmerwin/node-coveralls#github-actions-ci we are missing a branch env variable for github actions coverage support.