### PR TITLE
Avoid copying the histogram metric buckets.

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -57,7 +57,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   /// Increments counters given a count for each bucket. (i.e. the caller of
   /// this function must have already sorted the values into buckets).
   /// Also increments the total sum of all observations by the given value.
-  void ObserveMultiple(const std::vector<double> bucket_increments,
+  void ObserveMultiple(const std::vector<double>& bucket_increments,
                        const double sum_of_values);
 
   /// \brief Get the current value of the counter.

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -24,7 +24,7 @@ void Histogram::Observe(const double value) {
   bucket_counts_[bucket_index].Increment();
 }
 
-void Histogram::ObserveMultiple(const std::vector<double> bucket_increments,
+void Histogram::ObserveMultiple(const std::vector<double>& bucket_increments,
                                 const double sum_of_values) {
   if (bucket_increments.size() != bucket_counts_.size()) {
     throw std::length_error(


### PR DESCRIPTION
Thanks for the really nice to use library!

Whilst running `heaptrack` against a project that depends on it, I noticed we were allocating/free'ing a lot of memory somewhere. I tracked this down to a loop which was calling `ObserveMultiple`, passing a persistent `std::vector` object each time. I realised that the vector was being copied rather than being passed by reference.

Looking at the implementation of `ObserveMultiple`, it appears that passing by reference was the intention, and it was just a typo to miss the `&`, so this PR adds the missing ref qualifiers.