### PR TITLE
Include <ostream> in histogram.cc

### DIFF
--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <iterator>
 #include <numeric>
+#include <ostream>
 
 namespace prometheus {
 


### PR DESCRIPTION
In a future version of MSVC, \<string> doesn't transitively include\<ostream>.
This port will compile failed with histogram.cc(30): error C2039: 'length_error': is not a member of 'std', so I add include\<ostream> into the source file for fixing this issue.