### PR TITLE
Add support for serving multiple paths

### DIFF
--- a/pull/CMakeLists.txt
+++ b/pull/CMakeLists.txt
@@ -14,6 +14,7 @@ if(ENABLE_COMPRESSION)
 endif()
 
 add_library(pull
+  src/endpoint.cc
   src/exposer.cc
   src/handler.cc
   src/handler.h

--- a/pull/include/prometheus/endpoint.h
+++ b/pull/include/prometheus/endpoint.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+
+#include "prometheus/collectable.h"
+#include "prometheus/detail/pull_export.h"
+#include "prometheus/registry.h"
+
+namespace prometheus {
+
+namespace detail {
+class MetricsHandler;
+}  // namespace detail
+
+class PROMETHEUS_CPP_PULL_EXPORT Endpoint {
+ public:
+  explicit Endpoint(std::string uri);
+  ~Endpoint();
+
+  void RegisterCollectable(const std::weak_ptr<Collectable>& collectable);
+
+  detail::MetricsHandler* getMetricsHandler() const;
+
+  const std::string& getURI() const;
+
+ private:
+  std::vector<std::weak_ptr<Collectable>> collectables_;
+  // registry for "meta" metrics about the endpoint itself
+  std::shared_ptr<Registry> endpoint_registry_;
+  std::unique_ptr<detail::MetricsHandler> metrics_handler_;
+  std::string uri_;
+};
+
+}  // namespace prometheus

--- a/pull/src/endpoint.cc
+++ b/pull/src/endpoint.cc
@@ -1,0 +1,28 @@
+#include "prometheus/endpoint.h"
+
+#include "handler.h"
+
+namespace prometheus {
+
+Endpoint::Endpoint(std::string uri)
+    : endpoint_registry_(std::make_shared<Registry>()),
+      metrics_handler_(
+          new detail::MetricsHandler{collectables_, *endpoint_registry_}),
+      uri_(std::move(uri)) {
+  RegisterCollectable(endpoint_registry_);
+}
+
+Endpoint::~Endpoint() = default;
+
+void Endpoint::RegisterCollectable(
+    const std::weak_ptr<Collectable>& collectable) {
+  collectables_.push_back(collectable);
+}
+
+detail::MetricsHandler* Endpoint::getMetricsHandler() const {
+  return metrics_handler_.get();
+}
+
+const std::string& Endpoint::getURI() const { return uri_; }
+
+}  // namespace prometheus

--- a/pull/src/exposer.cc
+++ b/pull/src/exposer.cc
@@ -6,38 +6,52 @@
 
 #include "prometheus/client_metric.h"
 #include "prometheus/detail/future_std.h"
+#include "prometheus/endpoint.h"
 
 #include "CivetServer.h"
 #include "handler.h"
 
 namespace prometheus {
 
-Exposer::Exposer(const std::string& bind_address, const std::string& uri,
-                 const std::size_t num_threads)
-    : Exposer(
+MultiExposer::MultiExposer(const std::string& bind_address,
+                           std::vector<std::shared_ptr<Endpoint>> endpoints,
+                           const std::size_t num_threads)
+    : MultiExposer(
           std::vector<std::string>{"listening_ports", bind_address,
                                    "num_threads", std::to_string(num_threads)},
-          uri) {}
+          std::move(endpoints)) {}
 
-Exposer::Exposer(std::vector<std::string> options, const std::string& uri)
+MultiExposer::MultiExposer(std::vector<std::string> options,
+                           std::vector<std::shared_ptr<Endpoint>> endpoints)
     : server_(detail::make_unique<CivetServer>(std::move(options))),
-      exposer_registry_(std::make_shared<Registry>()),
-      metrics_handler_(
-          new detail::MetricsHandler{collectables_, *exposer_registry_}),
-      uri_(uri) {
-  RegisterCollectable(exposer_registry_);
-  server_->addHandler(uri, metrics_handler_.get());
+      endpoints_(std::move(endpoints)) {
+  for (const auto& endpoint : endpoints_) {
+    server_->addHandler(endpoint->getURI(), endpoint->getMetricsHandler());
+  }
 }
 
-Exposer::~Exposer() { server_->removeHandler(uri_); }
+MultiExposer::~MultiExposer() {
+  for (const auto& endpoint : endpoints_) {
+    server_->removeHandler(endpoint->getURI());
+  }
+}
+
+std::vector<int> MultiExposer::GetListeningPorts() const {
+  return server_->getListeningPorts();
+}
+
+Exposer::Exposer(const std::string& bind_address, const std::string& uri,
+                 const std::size_t num_threads)
+    : MultiExposer(bind_address, {std::make_shared<Endpoint>(uri)},
+                   num_threads) {}
+
+Exposer::Exposer(std::vector<std::string> options, const std::string& uri)
+    : MultiExposer(std::move(options), {std::make_shared<Endpoint>(uri)}) {}
 
 void Exposer::RegisterCollectable(
     const std::weak_ptr<Collectable>& collectable) {
-  collectables_.push_back(collectable);
-}
-
-std::vector<int> Exposer::GetListeningPorts() const {
-  return server_->getListeningPorts();
+  // Exposer is guaranteed to have a single Endpoint.
+  endpoints_.at(0)->RegisterCollectable(collectable);
 }
 
 }  // namespace prometheus

--- a/pull/tests/integration/BUILD.bazel
+++ b/pull/tests/integration/BUILD.bazel
@@ -4,6 +4,12 @@ cc_binary(
     deps = ["//pull"],
 )
 
+cc_binary(
+    name = "sample-server_multi",
+    srcs = ["sample_server_multi.cc"],
+    deps = ["//pull"],
+)
+
 sh_test(
     name = "scrape-test",
     size = "small",

--- a/pull/tests/integration/CMakeLists.txt
+++ b/pull/tests/integration/CMakeLists.txt
@@ -7,3 +7,13 @@ target_link_libraries(sample_server
   PRIVATE
     ${PROJECT_NAME}::pull
 )
+
+
+add_executable(sample_server_multi
+        sample_server_multi.cc
+        )
+
+target_link_libraries(sample_server_multi
+        PRIVATE
+        ${PROJECT_NAME}::pull
+        )

--- a/pull/tests/integration/sample_server_multi.cc
+++ b/pull/tests/integration/sample_server_multi.cc
@@ -1,0 +1,57 @@
+#include <prometheus/counter.h>
+#include <prometheus/endpoint.h>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+int main() {
+  using namespace prometheus;
+
+  auto endpointA = std::make_shared<Endpoint>("/metricsA");
+  auto endpointB = std::make_shared<Endpoint>("/metricsB");
+
+  auto registryA = std::make_shared<Registry>();
+
+  // add a new counter family to the registry (families combine values with the
+  // same name, but distinct label dimensions)
+  auto& counter_familyA = BuildCounter()
+                              .Name("time_running_seconds_total")
+                              .Help("How many seconds is this server running?")
+                              .Labels({{"label", "foo"}})
+                              .Register(*registryA);
+
+  // add a counter to the metric family
+  auto& seconds_counterA = counter_familyA.Add(
+      {{"another_label", "bar"}, {"yet_another_label", "baz"}});
+
+  // ask the exposer to scrape registryA on incoming scrapes for "/metricsA"
+  endpointA->RegisterCollectable(registryA);
+
+  auto registryB = std::make_shared<Registry>();
+
+  auto& counter_familyB = BuildCounter()
+                              .Name("other_time_running_seconds_total")
+                              .Help("How many seconds has something else been running?")
+                              .Labels({{"label", "not_foo"}})
+                              .Register(*registryB);
+
+  auto& seconds_counterB = counter_familyB.Add(
+      {{"another_label", "not_bar"}, {"yet_another_label", "not_baz"}});
+
+  // This endpoint exposes registryB.
+  endpointB->RegisterCollectable(registryB);
+
+  // create an http server running on port 8080
+  MultiExposer exposer{"127.0.0.1:8080", {endpointA, endpointB}, 1};
+
+  for (;;) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    // increment the counters by one (second)
+    seconds_counterA.Increment();
+    seconds_counterB.Increment();
+  }
+  return 0;
+}


### PR DESCRIPTION
In large projects it may be desired to have sets of stats with different scrape intervals and retention periods - currently that would require two `Exposer`s on different ports (AFAICT?).

This change shouldn't break existing usage of `Exposer` (but probably changes the ABI), but provides the option of having multiple endpoints with potentially different groups of `Collectable`s. These can then be served on a single civet server, on a single port.

If this is out of scope no worries, or if needs a version number bump let me know.