### PR TITLE
Add support for HTTP Basic Auth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "civetweb"]
 	path = 3rdparty/civetweb
 	url = https://github.com/civetweb/civetweb.git
+[submodule "3rdparty/cpp-base64"]
+	path = 3rdparty/cpp-base64
+	url = https://github.com/ReneNyffenegger/cpp-base64.git

--- a/cmake/cpp-base64-3rdparty-config.cmake
+++ b/cmake/cpp-base64-3rdparty-config.cmake
@@ -1,0 +1,8 @@
+get_filename_component(_IMPORT_PREFIX "${PROJECT_SOURCE_DIR}/3rdparty/cpp-base64/" ABSOLUTE)
+
+add_library(base64 OBJECT
+        ${_IMPORT_PREFIX}/base64.h
+        ${_IMPORT_PREFIX}/base64.cpp
+        )
+
+set(BASE64_INCLUDE_DIRS ${_IMPORT_PREFIX})

--- a/pull/CMakeLists.txt
+++ b/pull/CMakeLists.txt
@@ -13,7 +13,11 @@ if(ENABLE_COMPRESSION)
   find_package(ZLIB REQUIRED)
 endif()
 
+find_package(cpp-base64-3rdparty CONFIG REQUIRED)
+
 add_library(pull
+  src/basic_auth.cc
+  src/basic_auth.h
   src/endpoint.cc
   src/endpoint.h
   src/exposer.cc
@@ -21,6 +25,7 @@ add_library(pull
   src/handler.h
   src/metrics_collector.cc
   src/metrics_collector.h
+  $<TARGET_OBJECTS:base64>
 )
 
 add_library(${PROJECT_NAME}::pull ALIAS pull)
@@ -40,6 +45,7 @@ target_include_directories(pull
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   PRIVATE
+    ${BASE64_INCLUDE_DIRS}
     ${CIVETWEB_INCLUDE_DIRS}
 )
 

--- a/pull/include/prometheus/exposer.h
+++ b/pull/include/prometheus/exposer.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -27,6 +28,11 @@ class PROMETHEUS_CPP_PULL_EXPORT Exposer {
   ~Exposer();
   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
                            const std::string& uri = std::string("/metrics"));
+
+  void RegisterAuth(
+      std::function<bool(const std::string&, const std::string&)> authCB,
+      const std::string& realm = "Prometheus-cpp Exporter",
+      const std::string& uri = std::string("/metrics"));
 
   std::vector<int> GetListeningPorts() const;
 

--- a/pull/src/basic_auth.cc
+++ b/pull/src/basic_auth.cc
@@ -1,0 +1,75 @@
+#include "basic_auth.h"
+
+#include <base64.h>
+
+#include "CivetServer.h"
+#include "prometheus/detail/future_std.h"
+
+namespace prometheus {
+
+BasicAuthHandler::BasicAuthHandler(AuthFunc callback, std::string realm)
+    : callback_(std::move(callback)), realm_(std::move(realm)) {}
+
+bool BasicAuthHandler::authorize(CivetServer* server, mg_connection* conn) {
+  if (!AuthorizeInner(server, conn)) {
+    WriteUnauthorizedResponse(conn);
+    return false;
+  }
+  return true;
+}
+
+bool BasicAuthHandler::AuthorizeInner(CivetServer* server,
+                                      mg_connection* conn) {
+  const char* authHeader = mg_get_header(conn, "Authorization");
+
+  if (authHeader == nullptr) {
+    // No auth header was provided.
+    return false;
+  }
+  std::string authHeaderStr = authHeader;
+
+  // Basic auth header is expected to be of the form:
+  // "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+
+  const std::string prefix = "Basic ";
+  if (authHeaderStr.compare(0, prefix.size(), prefix) != 0) {
+    return false;
+  }
+
+  // Strip the "Basic " prefix leaving the base64 encoded auth string
+  auto b64Auth = authHeaderStr.substr(prefix.size());
+
+  std::string decoded;
+  try {
+    decoded = base64_decode(b64Auth);
+  } catch (...) {
+    return false;
+  }
+
+  // decoded auth string is expected to be of the form:
+  // "username:password"
+  // colons may not appear in the username.
+  auto splitPos = decoded.find(':');
+  if (splitPos == std::string::npos) {
+    return false;
+  }
+
+  auto username = decoded.substr(0, splitPos);
+  auto password = decoded.substr(splitPos + 1);
+
+  // TODO: bool does not permit a distinction between 401 Unauthorized
+  //  and 403 Forbidden. Authentication may succeed, but the user still
+  //  not be authorized to perform the request.
+  return callback_(username, password);
+}
+
+void BasicAuthHandler::WriteUnauthorizedResponse(mg_connection* conn) {
+  mg_printf(conn, "HTTP/1.1 401 Unauthorized\r\n");
+  mg_printf(conn, "WWW-Authenticate: Basic realm=\"%s\"\r\n", realm_.c_str());
+  mg_printf(conn, "Connection: close\r\n");
+  mg_printf(conn, "Content-Length: 0\r\n");
+  // end headers
+  mg_printf(conn, "\r\n");
+}
+
+}  // namespace prometheus

--- a/pull/src/basic_auth.h
+++ b/pull/src/basic_auth.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "CivetServer.h"
+#include "prometheus/detail/pull_export.h"
+
+namespace prometheus {
+
+/**
+ * Handler for HTTP Basic authentication for Endpoints.
+ */
+class PROMETHEUS_CPP_PULL_EXPORT BasicAuthHandler : public CivetAuthHandler {
+ public:
+  using AuthFunc = std::function<bool(const std::string&, const std::string&)>;
+  explicit BasicAuthHandler(AuthFunc callback, std::string realm);
+
+  /**
+   * Implements civetweb authorization interface.
+   *
+   * Attempts to extract a username and password from the Authorization header
+   * to pass to the owning AuthHandler, `this->handler`.
+   * If handler returns true, permits the request to proceed.
+   * If handler returns false, or the Auth header is absent,
+   * rejects the request with 401 Unauthorized.
+   */
+  bool authorize(CivetServer* server, mg_connection* conn) override;
+
+ private:
+  bool AuthorizeInner(CivetServer* server, mg_connection* conn);
+  void WriteUnauthorizedResponse(mg_connection* conn);
+
+  AuthFunc callback_;
+  std::string realm_;
+};
+
+}  // namespace prometheus

--- a/pull/src/endpoint.cc
+++ b/pull/src/endpoint.cc
@@ -1,5 +1,6 @@
 #include "endpoint.h"
 
+#include "basic_auth.h"
 #include "handler.h"
 #include "prometheus/detail/future_std.h"
 
@@ -16,11 +17,22 @@ Endpoint::Endpoint(CivetServer& server, std::string uri)
   server_.addHandler(uri_, metrics_handler_.get());
 }
 
-Endpoint::~Endpoint() { server_.removeHandler(uri_); }
+Endpoint::~Endpoint() {
+  server_.removeHandler(uri_);
+  server_.removeAuthHandler(uri_);
+}
 
 void Endpoint::RegisterCollectable(
     const std::weak_ptr<Collectable>& collectable) {
   collectables_.push_back(collectable);
+}
+
+void Endpoint::RegisterAuth(
+    std::function<bool(const std::string&, const std::string&)> authCB,
+    const std::string& realm) {
+  auth_handler_ =
+      detail::make_unique<BasicAuthHandler>(std::move(authCB), realm);
+  server_.addAuthHandler(uri_, auth_handler_.get());
 }
 
 const std::string& Endpoint::GetURI() const { return uri_; }

--- a/pull/src/endpoint.h
+++ b/pull/src/endpoint.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "basic_auth.h"
 #include "prometheus/collectable.h"
 #include "prometheus/registry.h"
 
@@ -19,6 +21,9 @@ class Endpoint {
   ~Endpoint();
 
   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable);
+  void RegisterAuth(
+      std::function<bool(const std::string&, const std::string&)> authCB,
+      const std::string& realm);
 
   const std::string& GetURI() const;
 
@@ -29,6 +34,7 @@ class Endpoint {
   // registry for "meta" metrics about the endpoint itself
   std::shared_ptr<Registry> endpoint_registry_;
   std::unique_ptr<MetricsHandler> metrics_handler_;
+  std::unique_ptr<BasicAuthHandler> auth_handler_;
 };
 
 }  // namespace detail

--- a/pull/src/exposer.cc
+++ b/pull/src/exposer.cc
@@ -28,6 +28,13 @@ void Exposer::RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
   endpoint.RegisterCollectable(collectable);
 }
 
+void Exposer::RegisterAuth(
+    std::function<bool(const std::string&, const std::string&)> authCB,
+    const std::string& realm, const std::string& uri) {
+  auto& endpoint = GetEndpointForUri(uri);
+  endpoint.RegisterAuth(std::move(authCB), realm);
+}
+
 std::vector<int> Exposer::GetListeningPorts() const {
   return server_->getListeningPorts();
 }

--- a/pull/tests/integration/BUILD.bazel
+++ b/pull/tests/integration/BUILD.bazel
@@ -10,6 +10,12 @@ cc_binary(
     deps = ["//pull"],
 )
 
+cc_binary(
+    name = "sample-server_auth",
+    srcs = ["sample_server_auth.cc"],
+    deps = ["//pull"],
+)
+
 sh_test(
     name = "scrape-test",
     size = "small",

--- a/pull/tests/integration/CMakeLists.txt
+++ b/pull/tests/integration/CMakeLists.txt
@@ -16,3 +16,12 @@ target_link_libraries(sample_server_multi
   PRIVATE
     ${PROJECT_NAME}::pull
 )
+
+add_executable(sample_server_auth
+  sample_server_auth.cc
+)
+
+target_link_libraries(sample_server_auth
+  PRIVATE
+     ${PROJECT_NAME}::pull
+)

--- a/pull/tests/integration/sample_server_auth.cc
+++ b/pull/tests/integration/sample_server_auth.cc
@@ -1,0 +1,42 @@
+#include <prometheus/counter.h>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+int main() {
+  using namespace prometheus;
+
+  // create an http server running on port 8080
+  Exposer exposer{"127.0.0.1:8080", 1};
+
+  auto registry = std::make_shared<Registry>();
+
+  // add a new counter family to the registry (families combine values with the
+  // same name, but distinct label dimensions)
+  auto& counter_family = BuildCounter()
+                             .Name("time_running_seconds_total")
+                             .Help("How many seconds is this server running?")
+                             .Register(*registry);
+
+  // add a counter to the metric family
+  auto& seconds_counter = counter_family.Add(
+      {{"another_label", "bar"}, {"yet_another_label", "baz"}});
+
+  // ask the exposer to scrape registry on incoming scrapes for "/metrics"
+  exposer.RegisterCollectable(registry, "/metrics");
+  exposer.RegisterAuth(
+      [](const std::string& user, const std::string& password) {
+        return user == "test_user" && password == "test_password";
+      },
+      "Some Auth Realm");
+
+  for (;;) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    // increment the counters by one (second)
+    seconds_counter.Increment(1.0);
+  }
+  return 0;
+}


### PR DESCRIPTION
Prometheus supports Basic Auth for [scrape targets](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).

This PR also adds a 3rd party base64 dependency. I've tried to match the existing thirdparty structure when adding it, but happy to change it if it doesn't match the preferred style.