### PR TITLE
Use a gauge for the histogram sum

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -4,6 +4,7 @@
 
 #include "prometheus/client_metric.h"
 #include "prometheus/counter.h"
+#include "prometheus/gauge.h"
 #include "prometheus/detail/builder.h"
 #include "prometheus/detail/core_export.h"
 #include "prometheus/metric_type.h"
@@ -19,7 +20,7 @@ namespace prometheus {
 /// values, allowing to calculate the average of the observed values.
 ///
 /// At its core a histogram has a counter per bucket. The sum of observations
-/// also behaves like a counter.
+/// also behaves like a counter as long as there are no negative observations.
 ///
 /// See https://prometheus.io/docs/practices/histograms/ for detailed
 /// explanations of histogram usage and differences to summaries.
@@ -68,7 +69,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
  private:
   const BucketBoundaries bucket_boundaries_;
   std::vector<Counter> bucket_counts_;
-  Counter sum_;
+  Gauge sum_;
 };
 
 /// \brief Return a builder to configure and register a Histogram metric.


### PR DESCRIPTION
The online docs for Prometheus state:

> The sum of observations (...) behaves like a counter, too, as long as
> there are no negative observations.

A counter can only ever go up and asserts that users pass in only positive values when incrementing. Hence, the `sum` must use a gauge in order to stay consistent with the Prometheus documentation.

Source for the quote: https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations