### PR TITLE
Avoid race when registering a collectable

### DIFF
--- a/pull/src/endpoint.cc
+++ b/pull/src/endpoint.cc
@@ -11,8 +11,8 @@ Endpoint::Endpoint(CivetServer& server, std::string uri)
     : server_(server),
       uri_(std::move(uri)),
       endpoint_registry_(std::make_shared<Registry>()),
-      metrics_handler_(detail::make_unique<MetricsHandler>(
-          collectables_, *endpoint_registry_)) {
+      metrics_handler_(
+          detail::make_unique<MetricsHandler>(*endpoint_registry_)) {
   RegisterCollectable(endpoint_registry_);
   server_.addHandler(uri_, metrics_handler_.get());
 }
@@ -24,7 +24,7 @@ Endpoint::~Endpoint() {
 
 void Endpoint::RegisterCollectable(
     const std::weak_ptr<Collectable>& collectable) {
-  collectables_.push_back(collectable);
+  metrics_handler_->RegisterCollectable(collectable);
 }
 
 void Endpoint::RegisterAuth(

--- a/pull/src/endpoint.h
+++ b/pull/src/endpoint.h
@@ -30,7 +30,6 @@ class Endpoint {
  private:
   CivetServer& server_;
   const std::string uri_;
-  std::vector<std::weak_ptr<Collectable>> collectables_;
   // registry for "meta" metrics about the endpoint itself
   std::shared_ptr<Registry> endpoint_registry_;
   std::unique_ptr<MetricsHandler> metrics_handler_;

--- a/pull/src/handler.h
+++ b/pull/src/handler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "CivetServer.h"
@@ -12,13 +13,15 @@ namespace prometheus {
 namespace detail {
 class MetricsHandler : public CivetHandler {
  public:
-  MetricsHandler(const std::vector<std::weak_ptr<Collectable>>& collectables,
-                 Registry& registry);
+  explicit MetricsHandler(Registry& registry);
+
+  void RegisterCollectable(const std::weak_ptr<Collectable>& collectable);
 
   bool handleGet(CivetServer* server, struct mg_connection* conn) override;
 
  private:
-  const std::vector<std::weak_ptr<Collectable>>& collectables_;
+  std::mutex collectables_mutex_;
+  std::vector<std::weak_ptr<Collectable>> collectables_;
   Family<Counter>& bytes_transferred_family_;
   Counter& bytes_transferred_;
   Family<Counter>& num_scrapes_family_;


### PR DESCRIPTION
A thread registering a `Collectable` with the `Exposer` may end up
invalidating iterators to the `collectables_` vector inside `Endpoint`
while a `CivetServer` handler thread is iterating the vector.

Move the `collectables_` vector to `MetricsHandler` where all accesses
can be guarded by a mutex.