### PR TITLE
Fix coverage from forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Prepare
         run: .github/scripts/run-prepare ${{ matrix.buildsystem }} ${{ matrix.os }}
       - name: Test
-        if: ${{ github.repository == "jupp0r/prometheus-cpp" }}
+        if: github.repository == 'jupp0r/prometheus-cpp'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_GIT_BRANCH: "${{ github.ref }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Prepare
         run: .github/scripts/run-prepare ${{ matrix.buildsystem }} ${{ matrix.os }}
       - name: Test
+        if: github.repository == "jupp0r/prometheus-cpp"
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_GIT_BRANCH: "${{ github.ref }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Prepare
         run: .github/scripts/run-prepare ${{ matrix.buildsystem }} ${{ matrix.os }}
       - name: Test
-        if: github.repository == "jupp0r/prometheus-cpp"
+        if: ${{ github.repository == "jupp0r/prometheus-cpp" }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_GIT_BRANCH: "${{ github.ref }}"


### PR DESCRIPTION
Understandably, pull requests originating in forks won't get access to secrets in github (in order to prevent them being extracted). This change makes coverage upload only run from PRs or pushes originating in this repo, getting rid of failures for external contributors.