### PR TITLE
More efficient use of curl by reusing handle across requests

### DIFF
--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -49,6 +49,7 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   std::string labels_;
   std::string auth_;
   std::unique_ptr<CurlWrapper> curlWrapper_;
+  std::mutex mutex_;
 
   using CollectableEntry = std::pair<std::weak_ptr<Collectable>, std::string>;
   std::vector<CollectableEntry> collectables_;

--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -6,14 +6,13 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <mutex>
 
 #include "prometheus/detail/push_export.h"
 #include "prometheus/registry.h"
 
-#include <curl/curl.h>
-
 namespace prometheus {
+
+class CurlWrapper;
 
 class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
  public:
@@ -49,8 +48,7 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   std::string jobUri_;
   std::string labels_;
   std::string auth_;
-  CURL *curl_;
-  std::mutex curlMutex_;
+  std::unique_ptr<CurlWrapper> curlWrapper_;
 
   using CollectableEntry = std::pair<std::weak_ptr<Collectable>, std::string>;
   std::vector<CollectableEntry> collectables_;

--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -6,9 +6,12 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "prometheus/detail/push_export.h"
 #include "prometheus/registry.h"
+
+#include <curl/curl.h>
 
 namespace prometheus {
 
@@ -46,6 +49,8 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   std::string jobUri_;
   std::string labels_;
   std::string auth_;
+  CURL *curl_;
+  std::mutex curlMutex_;
 
   using CollectableEntry = std::pair<std::weak_ptr<Collectable>, std::string>;
   std::vector<CollectableEntry> collectables_;
@@ -59,7 +64,7 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   };
 
   int performHttpRequest(HttpMethod method, const std::string& uri,
-                         const std::string& body) const;
+                         const std::string& body);
 
   int push(HttpMethod method);
 

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -22,14 +22,12 @@ public:
     curl_ = nullptr;
   }
   ~CurlWrapper() {
-    std::lock_guard<std::mutex> l(mutex_);
     if (curl_) {
       curl_easy_cleanup(curl_);
     }
   }
 
   CURL *curl() {
-    std::lock_guard<std::mutex> l(mutex_);
     if (!curl_) {
       curl_ = curl_easy_init();
     }
@@ -38,7 +36,6 @@ public:
 
 private:
   CURL *curl_;
-  std::mutex mutex_;
 };
 
 Gateway::Gateway(const std::string host, const std::string port,
@@ -87,7 +84,8 @@ void Gateway::RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
 
 int Gateway::performHttpRequest(HttpMethod method, const std::string& uri,
                                 const std::string& body) {
-
+  std::lock_guard<std::mutex> l(mutex_);
+  
   auto curl = curlWrapper_->curl();
   if (!curl) {
     return -CURLE_FAILED_INIT;

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -8,8 +8,6 @@
 #include "prometheus/serializer.h"
 #include "prometheus/text_serializer.h"
 
-#include <curl/curl.h>
-
 namespace prometheus {
 
 static const char CONTENT_TYPE[] =
@@ -34,9 +32,16 @@ Gateway::Gateway(const std::string host, const std::string port,
     labelStream << "/" << label.first << "/" << label.second;
   }
   labels_ = labelStream.str();
+  curl_ = nullptr;
 }
 
-Gateway::~Gateway() { curl_global_cleanup(); }
+Gateway::~Gateway() { 
+  std::lock_guard<std::mutex> l(curlMutex_);
+  if (curl_) {
+    curl_easy_cleanup(curl_);
+  }
+  curl_global_cleanup(); 
+}
 
 const Gateway::Labels Gateway::GetInstanceLabel(std::string hostname) {
   if (hostname.empty()) {
@@ -59,53 +64,55 @@ void Gateway::RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
 }
 
 int Gateway::performHttpRequest(HttpMethod method, const std::string& uri,
-                                const std::string& body) const {
-  auto curl = curl_easy_init();
-  if (!curl) {
-    return -CURLE_FAILED_INIT;
+                                const std::string& body) {
+  std::lock_guard<std::mutex> l(curlMutex_);
+  if (!curl_) {
+    curl_ = curl_easy_init();
+    if (!curl_) {
+      return -CURLE_FAILED_INIT;
+    }
   }
-
-  curl_easy_setopt(curl, CURLOPT_URL, uri.c_str());
+  curl_easy_reset(curl_);
+  curl_easy_setopt(curl_, CURLOPT_URL, uri.c_str());
 
   curl_slist* header_chunk = nullptr;
 
   if (!body.empty()) {
     header_chunk = curl_slist_append(nullptr, CONTENT_TYPE);
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_chunk);
+    curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, header_chunk);
 
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, body.size());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.data());
+    curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, body.size());
+    curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, body.data());
   }
 
   if (!auth_.empty()) {
-    curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-    curl_easy_setopt(curl, CURLOPT_USERPWD, auth_.c_str());
+    curl_easy_setopt(curl_, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_easy_setopt(curl_, CURLOPT_USERPWD, auth_.c_str());
   }
 
   switch (method) {
     case HttpMethod::Post:
-      curl_easy_setopt(curl, CURLOPT_HTTPGET, 0L);
-      curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
+      curl_easy_setopt(curl_, CURLOPT_HTTPGET, 0L);
+      curl_easy_setopt(curl_, CURLOPT_NOBODY, 0L);
       break;
 
     case HttpMethod::Put:
-      curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
-      curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+      curl_easy_setopt(curl_, CURLOPT_NOBODY, 0L);
+      curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "PUT");
       break;
 
     case HttpMethod::Delete:
-      curl_easy_setopt(curl, CURLOPT_HTTPGET, 0L);
-      curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
-      curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+      curl_easy_setopt(curl_, CURLOPT_HTTPGET, 0L);
+      curl_easy_setopt(curl_, CURLOPT_NOBODY, 0L);
+      curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "DELETE");
       break;
   }
 
-  auto curl_error = curl_easy_perform(curl);
+  auto curl_error = curl_easy_perform(curl_);
 
   long response_code;
-  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+  curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &response_code);
 
-  curl_easy_cleanup(curl);
   curl_slist_free_all(header_chunk);
 
   if (curl_error != CURLE_OK) {


### PR DESCRIPTION
This PR changes how the push gateway performs http operations by reusing `CURL` handle throughout the lifetime of the gateway object, preserving the underlying tcp connection.

Previously, each collectable iteration would re-create the handle, unnecessarily re-establishing the tcp connection many times during a single run.
