### PR TITLE
core: Explicitly link against libatomic when needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ endif()
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)
 
+# check for required libatomic
+
+include(CheckAtomic)
+
 if(ENABLE_TESTING)
   if(USE_THIRDPARTY_LIBRARIES)
     find_package(googlemock-3rdparty CONFIG REQUIRED)

--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -1,0 +1,37 @@
+# Inspired by CheckAtomic.cmake from LLVM project:
+# https://github.com/llvm/llvm-project/blob/master/llvm/cmake/modules/CheckAtomic.cmake
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(CheckCXXSourceCompiles)
+include(CheckLibraryExists)
+
+function(check_working_cxx_atomics varname)
+  check_cxx_source_compiles("
+#include <atomic>
+#include <cstdint>
+std::atomic<std::uint64_t> x(0);
+int main() {
+  std::uint64_t i = x.load(std::memory_order_relaxed);
+  return 0;
+}
+" ${varname})
+endfunction()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  # First check if atomics work without the library.
+  check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+  # If not, check if the library exists, and atomics work with it.
+  if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMIC)
+    if(HAVE_CXX_LIBATOMIC)
+      list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+      check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+      if(NOT HAVE_CXX_ATOMICS_WITH_LIB)
+        message(FATAL_ERROR "Host compiler must support 64-bit std::atomic!")
+      endif()
+    else()
+      message(FATAL_ERROR "Host compiler appears to require libatomic for 64-bit operations, but cannot find it.")
+    endif()
+  endif()
+endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -23,6 +23,12 @@ target_link_libraries(core
     $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
 )
 
+if(HAVE_CXX_LIBATOMIC)
+  # the exported library config must use libatomic unconditionally
+  # (the HAVE_CXX_LIBATOMIC variable should not leak into the target config)
+  target_link_libraries(core PUBLIC atomic)
+endif()
+
 target_include_directories(core
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/pull/include/prometheus/exposer.h
+++ b/pull/include/prometheus/exposer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
@stackjohn On my Raspberry Pi OS I see the following which triggers the automatic linking of libatomic:

```
-- Performing Test HAVE_CXX_ATOMICS_WITHOUT_LIB
-- Performing Test HAVE_CXX_ATOMICS_WITHOUT_LIB - Failed
-- Looking for __atomic_load_8 in atomic
-- Looking for __atomic_load_8 in atomic - found
-- Performing Test HAVE_CXX_ATOMICS_WITH_LIB
-- Performing Test HAVE_CXX_ATOMICS_WITH_LIB - Success
```

Closes: #394