### PR TITLE
feat: allow selection of MSVC runtime library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW) # recognize CMAKE_MSVC_RUNTIME_LIBRARY
+endif()
 
 project(prometheus-cpp VERSION 0.10.0)
 


### PR DESCRIPTION
to select the static runtime use at least CMake 3.15
and pass `-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>`
to CMake when configuring.

Fixes: #410