### PR TITLE
Optimistically return metrics from the cache (if present) 

### DIFF
--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -109,6 +109,8 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   /// labels already exists - the already existing dimensional data.
   template <typename... Args>
   T& Add(const std::map<std::string, std::string>& labels, Args&&... args) {
+    T* metric = GetMetric(labels);
+    if (metric) return *metric;
     return Add(labels, detail::make_unique<T>(args...));
   }
 
@@ -148,6 +150,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   ClientMetric CollectMetric(std::size_t hash, T* metric) const;
   T& Add(const std::map<std::string, std::string>& labels,
          std::unique_ptr<T> object);
+  T* GetMetric(const std::map<std::string, std::string>& labels) const;
 };
 
 }  // namespace prometheus

--- a/core/src/family.cc
+++ b/core/src/family.cc
@@ -15,6 +15,25 @@ Family<T>::Family(const std::string& name, const std::string& help,
 }
 
 template <typename T>
+T* Family<T>::GetMetric(const std::map<std::string, std::string>& labels) const {
+  auto hash = detail::hash_labels(labels);
+  std::lock_guard<std::mutex> lock{mutex_};
+  auto metrics_iter = metrics_.find(hash);
+
+  if (metrics_iter == metrics_.end())
+    return nullptr;
+
+#ifndef NDEBUG
+    auto labels_iter = labels_.find(hash);
+    assert(labels_iter != labels_.end());
+    const auto& old_labels = labels_iter->second;
+    assert(labels == old_labels);
+#endif
+
+  return metrics_iter->second.get();
+}
+
+template <typename T>
 T& Family<T>::Add(const std::map<std::string, std::string>& labels,
                   std::unique_ptr<T> object) {
   auto hash = detail::hash_labels(labels);


### PR DESCRIPTION
*before* building a metric to add to the cache.