### PR TITLE
Added missing include

### DIFF
--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <ostream>
 


### PR DESCRIPTION
Without it, the project doesn't compile with `libstdc++-11` (works fine on `libstdc++-10` though). 