### PR TITLE
core: Replace name check regex

### DIFF
--- a/core/tests/check_names_test.cc
+++ b/core/tests/check_names_test.cc
@@ -16,6 +16,15 @@ TEST(CheckNamesTest, malformed_metric_name) {
   EXPECT_FALSE(CheckMetricName("fa mi ly with space in name or |"));
 }
 TEST(CheckNamesTest, empty_label_name) { EXPECT_FALSE(CheckLabelName("")); }
+TEST(CheckNamesTest, invalid_label_name) {
+  EXPECT_FALSE(CheckLabelName("log-level"));
+}
+TEST(CheckNamesTest, leading_invalid_label_name) {
+  EXPECT_FALSE(CheckLabelName("-abcd"));
+}
+TEST(CheckNamesTest, trailing_invalid_label_name) {
+  EXPECT_FALSE(CheckLabelName("abcd-"));
+}
 TEST(CheckNamesTest, good_label_name) { EXPECT_TRUE(CheckLabelName("type")); }
 TEST(CheckNamesTest, reserved_label_name) {
   EXPECT_FALSE(CheckMetricName("__some_reserved_label"));


### PR DESCRIPTION
The std::regex has the problem that it is not available everywhere
and also it's 75 times slower than the naive validity check.
    
```
BM_Label_Check_Regex          550 ns          550 ns      1270601
BM_Label_Check_NoRegex       7.50 ns         7.50 ns     92802503
```

Issue: #459