### PR TITLE
add prometheus variable labels method(LabelVec,WithLabelValues) support

### DIFF
--- a/core/benchmarks/registry_bench.cc
+++ b/core/benchmarks/registry_bench.cc
@@ -42,3 +42,37 @@ static void BM_Registry_CreateCounter(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_Registry_CreateCounter)->Range(0, 4096);
+
+static void BM_Registry_CreateCounter_WithLabelValues(benchmark::State& state) {
+  using prometheus::BuildCounter;
+  using prometheus::Counter;
+  using prometheus::Registry;
+  Registry registry;
+
+  const auto& labels = GenerateRandomLabels(state.range(0));
+  std::vector<std::string> label_names;
+  std::vector<std::string> label_values;
+  std::for_each(labels.begin(), labels.end(),
+                [&](const std::pair<std::string,std::string>& p){
+                  label_names.push_back(p.first);
+                  label_values.push_back(p.second);
+                });
+
+  auto& counter_family = BuildCounter()
+          .Labels(GenerateRandomLabels(10))
+          .Name("benchmark_counter")
+          .Help("")
+          .LabelNamesVec(label_names)
+          .Register(registry);
+
+  while (state.KeepRunning()) {
+    auto start = std::chrono::high_resolution_clock::now();
+    counter_family.WithLabelValues(label_values);
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto elapsed_seconds =
+            std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
+    state.SetIterationTime(elapsed_seconds.count());
+  }
+}
+BENCHMARK(BM_Registry_CreateCounter_WithLabelValues)->Range(0, 4096);

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -5,6 +5,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/gauge.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 
@@ -64,6 +65,22 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
 ///                            .Labels({{"key", "value"}})
 ///                            .Register(*registry);
 ///
+/// counter_family.Add({{"key2","value2"}}).Increment();
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& counter_family = prometheus::BuildCounter()
+///                            .Name("some_name")
+///                            .Help("Additional description.")
+///                            .Labels({{"key", "value"}})
+///                            .LabelNamesVec({"key2","key3"})
+///                            .Register(*registry);
+///
+/// counter_family.WithLabelValues({"value2","value3"}).Increment();
 /// ...
 /// \endcode
 ///
@@ -74,9 +91,16 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
 ///
 /// To finish the configuration of the Counter metric, register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Counter> BuildCounter();
+
+/// \brief Specialization of WithLabelValues<Counter>.
+PROMETHEUS_CPP_CORE_EXPORT template <>
+Counter& Family<Counter>::WithLabelValues(const std::vector<std::string>& values);
 
 }  // namespace prometheus

--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -1,13 +1,18 @@
 #pragma once
 
 #include <map>
+#include <vector>
 #include <string>
+#include "prometheus/detail/ckms_quantiles.h"
 
 // IWYU pragma: private
 // IWYU pragma: no_include "prometheus/family.h"
 
 namespace prometheus {
 
+class Counter;
+class Summary;
+class Histogram;
 template <typename T>
 class Family;    // IWYU pragma: keep
 class Registry;  // IWYU pragma: keep
@@ -18,15 +23,39 @@ template <typename T>
 class Builder {
  public:
   Builder& Labels(const std::map<std::string, std::string>& labels);
+  Builder& LabelNamesVec(const std::vector<std::string>& labels);
   Builder& Name(const std::string&);
   Builder& Help(const std::string&);
   Family<T>& Register(Registry&);
 
- private:
+  template <typename U= T, typename = typename std::enable_if<std::is_same<U, Summary>::value,Summary>::type>
+  Builder& Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>&);
+
+  template <typename U= T, typename = typename std::enable_if<std::is_same<U, Histogram>::value,Histogram>::type>
+  Builder& BucketBoundaries(const std::vector<double>&);
+
+private:
   std::map<std::string, std::string> labels_;
+  std::vector<std::string> variable_labels_;
+  std::vector<detail::CKMSQuantiles::Quantile> quantiles_;
+  std::vector<double> bucket_boundaries_;
   std::string name_;
   std::string help_;
 };
+
+template<typename T>
+template<typename U, typename>
+Builder<T>& Builder<T>::Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>& quantiles) {
+  quantiles_ = quantiles;
+  return *this;
+}
+
+template<typename T>
+template<typename U, typename>
+Builder<T>& Builder<T>::BucketBoundaries(const std::vector<double>& bucket_boundaries) {
+  bucket_boundaries_ = bucket_boundaries;
+  return *this;
+}
 
 }  // namespace detail
 }  // namespace prometheus

--- a/core/include/prometheus/detail/ckms_quantiles.h
+++ b/core/include/prometheus/detail/ckms_quantiles.h
@@ -15,10 +15,10 @@ namespace detail {
 class PROMETHEUS_CPP_CORE_EXPORT CKMSQuantiles {
  public:
   struct PROMETHEUS_CPP_CORE_EXPORT Quantile {
-    const double quantile;
-    const double error;
-    const double u;
-    const double v;
+    double quantile;
+    double error;
+    double u;
+    double v;
 
     Quantile(double quantile, double error);
   };

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -12,6 +12,8 @@
 #include "prometheus/collectable.h"
 #include "prometheus/detail/core_export.h"
 #include "prometheus/detail/future_std.h"
+#include "prometheus/detail/utils.h"
+#include "prometheus/detail/ckms_quantiles.h"
 #include "prometheus/metric_family.h"
 
 // IWYU pragma: no_include "prometheus/counter.h"
@@ -20,6 +22,9 @@
 // IWYU pragma: no_include "prometheus/summary.h"
 
 namespace prometheus {
+
+class Summary;
+class Histogram;
 
 /// \brief A metric of type T with a set of labeled dimensions.
 ///
@@ -91,6 +96,10 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   Family(const std::string& name, const std::string& help,
          const std::map<std::string, std::string>& constant_labels);
 
+  Family(const std::string& name, const std::string& help,
+         const std::vector<std::string>& variable_labels,
+         const std::map<std::string, std::string>& constant_labels);
+
   /// \brief Add a new dimensional data.
   ///
   /// Each new set of labels adds a new dimensional data and is exposed in
@@ -112,6 +121,23 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   T& Add(const std::map<std::string, std::string>& labels, Args&&... args) {
     return Add(labels, detail::make_unique<T>(args...));
   }
+  /// \brief Add a new dimensional data.
+  /// different with Add, this method call only when build<T>.LavelVec(...)
+  /// is call before.
+  /// then this method call Add
+  T& WithLabelValues(const std::vector<std::string>& values);
+
+  /// \brief when T is Summary, set the Quantiles.
+  /// should be call before call WithLabelValues
+  template <typename U = T>
+  typename std::enable_if<(std::is_same<U, Summary>::value), Family<T>&>::type
+  SetQuantiles(std::vector<detail::CKMSQuantiles::Quantile>& quantiles);
+
+  /// \brief when T is Summary, set the BucketBoundaries.
+  /// should be call before call WithLabelValues
+  template <typename U = T>
+  typename std::enable_if<(std::is_same<U, Histogram>::value), Family<T>&>::type
+  SetBucketBoundaries(std::vector<double>& bucket_boundaries);
 
   /// \brief Remove the given dimensional data.
   ///
@@ -143,12 +169,34 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
 
   const std::string name_;
   const std::string help_;
+  std::vector<std::string> variable_labels_;
   const std::map<std::string, std::string> constant_labels_;
+  std::vector<detail::CKMSQuantiles::Quantile> quantiles_;
+  std::vector<double> bucket_boundaries_;
   mutable std::mutex mutex_;
 
   ClientMetric CollectMetric(std::size_t hash, T* metric) const;
   T& Add(const std::map<std::string, std::string>& labels,
          std::unique_ptr<T> object);
+  std::map<std::string, std::string> VariableLabels(
+          const std::vector<std::string>& values);
 };
+
+template <typename T>
+template <typename U>
+typename std::enable_if<(std::is_same<U, Summary>::value), Family<T>&>::type
+Family<T>::SetQuantiles(std::vector<detail::CKMSQuantiles::Quantile>& quantiles){
+  quantiles_ = quantiles;
+  return *this;
+}
+
+template <typename T>
+template <typename U>
+typename std::enable_if<(std::is_same<U, Histogram>::value), Family<T>&>::type
+Family<T>::SetBucketBoundaries(std::vector<double>& bucket_boundaries){
+  bucket_boundaries_ = bucket_boundaries;
+  return *this;
+}
+
 
 }  // namespace prometheus

--- a/core/include/prometheus/gauge.h
+++ b/core/include/prometheus/gauge.h
@@ -6,6 +6,7 @@
 #include "prometheus/detail/builder.h"  // IWYU pragma: export
 #include "prometheus/detail/core_export.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 
@@ -76,6 +77,22 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
 ///                          .Labels({{"key", "value"}})
 ///                          .Register(*registry);
 ///
+/// gauge_family.Add({{"key2","value2"}}).Increment();
+/// ...
+/// \endcode
+///
+/// Example usage:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& gauge_family = prometheus::BuildGauge()
+///                          .Name("some_name")
+///                          .Help("Additional description.")
+///                          .Labels({{"key", "value"}})
+///                          .LabelNamesVec({"key2","key3"})
+///                          .Register(*registry);
+///
+/// gauge_family.WithLabelValues({"value2","value3"}).Increment();
 /// ...
 /// \endcode
 ///
@@ -86,9 +103,16 @@ class PROMETHEUS_CPP_CORE_EXPORT Gauge {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
 ///
 /// To finish the configuration of the Gauge metric register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Gauge> BuildGauge();
+
+/// \brief Specialization of WithLabelValues<Gauge>.
+PROMETHEUS_CPP_CORE_EXPORT template <>
+Gauge& Family<Gauge>::WithLabelValues(const std::vector<std::string>& values);
 
 }  // namespace prometheus

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -8,6 +8,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/gauge.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 
@@ -28,6 +29,18 @@ namespace prometheus {
 /// The class is thread-safe. No concurrent call to any API of this type causes
 /// a data race.
 class PROMETHEUS_CPP_CORE_EXPORT Histogram {
+ public:
+
+  /// \brief ExponentialBuckets creates 'count' buckets, where the lowest bucket has an
+  /// upper bound of 'start' and each following bucket's upper bound is 'factor'
+  /// times the previous bucket's upper bound. The final +Inf bucket is not counted
+  /// and not included in the returned vector. The returned vector is meant to be
+  /// used for the Buckets field of Histogram.
+  ///
+  /// The function assert if 'count' is 0 or negative, if 'start' is 0 or negative,
+  /// or if 'factor' is less than or equal 1.
+  static std::vector<double> ExponentialBuckets(double start,
+         double factor, int count);
  public:
   using BucketBoundaries = std::vector<double>;
 
@@ -86,6 +99,23 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 ///                              .Labels({{"key", "value"}})
 ///                              .Register(*registry);
 ///
+/// histogram_family.Add({{"key1","value1"}}, Histogram::BucketBoundaries{1, 2}).Observe(1.0);
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& histogram_family = prometheus::BuildHistogram()
+///                              .Name("some_name")
+///                              .Help("Additional description.")
+///                              .Labels({{"key", "value"}})
+///                              .LabelNamesVec({"key2","key3"})
+///                              .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
+///                              .Register(*registry);
+///
+/// histogram_family.WithLabelValues({"value2","value3"}).Observe(1.0);
 /// ...
 /// \endcode
 ///
@@ -96,9 +126,24 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
+/// - BucketBoundaries(const std::vector<double>&) to pre-affirmation bucketBoundaries
+///   when use WithLabelValues()
 ///
 /// To finish the configuration of the Histogram metric register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Histogram> BuildHistogram();
+
+/// \brief Specialization of WithLabelValues<Histogram>.
+PROMETHEUS_CPP_CORE_EXPORT template <>
+Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values);
+
+namespace detail {
+/// \brief Specialization of Register<Histogram>.
+PROMETHEUS_CPP_CORE_EXPORT template<>
+Family <Histogram> &Builder<Histogram>::Register(Registry &registry);
+}  // namespace detail
 
 }  // namespace prometheus

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -84,6 +84,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
 
   template <typename T>
   Family<T>& Add(const std::string& name, const std::string& help,
+                 const std::vector<std::string>& variable_labels,
                  const std::map<std::string, std::string>& labels);
 
   const InsertBehavior insert_behavior_;

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -11,6 +11,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/detail/time_window_quantiles.h"
 #include "prometheus/metric_type.h"
+#include "prometheus/family.h"
 
 namespace prometheus {
 
@@ -105,6 +106,23 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
 ///                            .Labels({{"key", "value"}})
 ///                            .Register(*registry);
 ///
+/// summary_family.Add({{"key1","value1"}}, Summary::Quantiles{}).Observe(1.0);
+/// ...
+/// \endcode
+///
+/// Example usage2:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& summary_family = prometheus::BuildSummary()
+///                            .Name("some_name")
+///                            .Help("Additional description.")
+///                            .Labels({{"key", "value"}})
+/////                          .LabelNamesVec({"key2","key3"})
+///                            .Quantiles(Summary::Quantiles{})
+///                            .Register(*registry);
+///
+/// summary_family.WithLabelValues({"value2","value3"}).Observe(1.0);
 /// ...
 /// \endcode
 ///
@@ -115,9 +133,24 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
 /// - Help(const std::string&) to set an additional description.
 /// - Label(const std::map<std::string, std::string>&) to assign a set of
 ///   key-value pairs (= labels) to the metric.
+/// - LabelNamesVec(const std::vector<std::string&) to pre-affirmation pairs(= labels)'s
+///   key; and you and use family.WithLabelValues({"value1","value1"}) to get the T;
+///   note than: vector<names>.size() == vector<values>.size()
+/// - Quantiles(const std::vector<detail::CKMSQuantiles::Quantile>&) to pre-affirmation Quantiles
+///   when use WithLabelValues()
 ///
 /// To finish the configuration of the Summary metric register it with
 /// Register(Registry&).
 PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Summary> BuildSummary();
+
+/// \brief Specialization of WithLabelValues<Summary>.
+PROMETHEUS_CPP_CORE_EXPORT template <>
+Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values);
+
+namespace detail {
+/// \brief Specialization of Register<Summary>.
+PROMETHEUS_CPP_CORE_EXPORT template<>
+Family<Summary>& detail::Builder<Summary>::Register(Registry& registry);
+}  // namespace detail
 
 }  // namespace prometheus

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -19,6 +19,13 @@ Builder<T>& Builder<T>::Labels(
 }
 
 template <typename T>
+Builder<T>& Builder<T>::LabelNamesVec(
+        const std::vector<std::string>& labels) {
+  variable_labels_ = labels;
+  return *this;
+}
+
+template <typename T>
 Builder<T>& Builder<T>::Name(const std::string& name) {
   name_ = name;
   return *this;
@@ -32,13 +39,27 @@ Builder<T>& Builder<T>::Help(const std::string& help) {
 
 template <typename T>
 Family<T>& Builder<T>::Register(Registry& registry) {
-  return registry.Add<T>(name_, help_, labels_);
+  return registry.Add<T>(name_, help_, variable_labels_, labels_);
 }
 
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Counter>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Gauge>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Histogram>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Summary>;
+
+
+template<>
+Family<Histogram>& detail::Builder<Histogram>::Register(Registry& registry){
+  Family<Histogram>& family = registry.Add<Histogram>(name_, help_, variable_labels_, labels_);
+  return family.SetBucketBoundaries(bucket_boundaries_);
+}
+
+template<>
+Family<Summary> &detail::Builder<Summary>::Register(Registry &registry) {
+  Family<Summary> &family = registry.Add<Summary>(name_, help_, variable_labels_, labels_);
+  return family.SetQuantiles(quantiles_);
+}
+
 
 }  // namespace detail
 

--- a/core/src/family.cc
+++ b/core/src/family.cc
@@ -30,6 +30,36 @@ Family<T>::Family(const std::string& name, const std::string& help,
 }
 
 template <typename T>
+Family<T>::Family(const std::string& name, const std::string& help,
+                  const std::vector<std::string>& variable_labels,
+                  const std::map<std::string, std::string>& constant_labels)
+        : name_(name), help_(help), variable_labels_(variable_labels),
+          constant_labels_(constant_labels) {
+  assert(CheckMetricName(name_));
+}
+
+template <typename T>
+std::map<std::string, std::string> Family<T>::VariableLabels(const std::vector<std::string>& values)
+{
+  if (variable_labels_.size() != values.size()) {
+    throw std::length_error("The size of variable_labels was not equal to"
+                            "the number of values when call WithLabelValues.");
+  }
+  std::map<std::string, std::string> labels_map;
+
+  int i = 0;
+  for (auto str : variable_labels_) {
+    labels_map.emplace(str, values[i++]);
+  }
+  return labels_map;
+}
+
+template <typename T>
+T& Family<T>::WithLabelValues(const std::vector<std::string>& values) {
+  return Add(VariableLabels(values));
+}
+
+template <typename T>
 T& Family<T>::Add(const std::map<std::string, std::string>& labels,
                   std::unique_ptr<T> object) {
   auto hash = detail::hash_labels(labels);
@@ -119,10 +149,30 @@ ClientMetric Family<T>::CollectMetric(std::size_t hash, T* metric) const {
   std::for_each(metric_labels.cbegin(), metric_labels.cend(), add_label);
   return collected;
 }
-
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Counter>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Gauge>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Histogram>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Summary>;
+
+
+template <>
+Gauge& Family<Gauge>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values));
+}
+
+template <>
+Counter& Family<Counter>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values));
+}
+
+template <>
+Summary& Family<Summary>::WithLabelValues(const std::vector<std::string>& values) {
+  return Add(VariableLabels(values), quantiles_);
+}
+
+template <>
+Histogram& Family<Histogram>::WithLabelValues(const std::vector<std::string>& values) {\
+  return Add(VariableLabels(values), bucket_boundaries_);
+}
 
 }  // namespace prometheus

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -1,4 +1,5 @@
 #include "prometheus/histogram.h"
+#include "prometheus/registry.h"
 
 #include <algorithm>
 #include <cassert>
@@ -10,6 +11,20 @@
 #include <utility>
 
 namespace prometheus {
+
+std::vector<double> Histogram::ExponentialBuckets(double start,
+        double factor, int count) {
+  assert(count >= 1);
+  assert(start > 0);
+  assert(factor > 1);
+
+  std::vector<double> buckets;
+  for (int i=0; i < count; i++) {
+    buckets.push_back(start);
+    start *= factor;
+  }
+  return buckets;
+}
 
 Histogram::Histogram(const BucketBoundaries& buckets)
     : bucket_boundaries_{buckets}, bucket_counts_{buckets.size() + 1}, sum_{} {

--- a/core/src/registry.cc
+++ b/core/src/registry.cc
@@ -96,6 +96,7 @@ bool Registry::NameExistsInOtherType<Summary>(const std::string& name) const {
 
 template <typename T>
 Family<T>& Registry::Add(const std::string& name, const std::string& help,
+                         const std::vector<std::string>& variable_labels,
                          const std::map<std::string, std::string>& labels) {
   std::lock_guard<std::mutex> lock{mutex_};
 
@@ -131,7 +132,7 @@ Family<T>& Registry::Add(const std::string& name, const std::string& help,
     }
   }
 
-  auto family = detail::make_unique<Family<T>>(name, help, labels);
+  auto family = detail::make_unique<Family<T>>(name, help, variable_labels, labels);
   auto& ref = *family;
   families.push_back(std::move(family));
   return ref;
@@ -139,18 +140,22 @@ Family<T>& Registry::Add(const std::string& name, const std::string& help,
 
 template Family<Counter>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 template Family<Gauge>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 template Family<Summary>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 template Family<Histogram>& Registry::Add(
     const std::string& name, const std::string& help,
+    const std::vector<std::string>& variable_labels,
     const std::map<std::string, std::string>& labels);
 
 }  // namespace prometheus

--- a/core/src/summary.cc
+++ b/core/src/summary.cc
@@ -1,4 +1,5 @@
 #include "prometheus/summary.h"
+#include "prometheus/registry.h"
 
 #include <utility>
 

--- a/core/tests/builder_test.cc
+++ b/core/tests/builder_test.cc
@@ -22,21 +22,36 @@ namespace {
 
 class BuilderTest : public testing::Test {
  protected:
+  enum class Variable { no, yes };
+
+  template <Variable v>
   std::vector<ClientMetric::Label> getExpectedLabels() {
     std::vector<ClientMetric::Label> labels;
 
-    auto gen = [](std::pair<const std::string, std::string> p) {
+    int i = 0;
+    auto gen_pair = [](std::pair<const std::string, std::string> p) {
       return ClientMetric::Label{p.first, p.second};
     };
+    auto gen_vec = [&](const std::string k) {
+      return ClientMetric::Label{k, variable_values[i++]};
+    };
+
 
     std::transform(std::begin(const_labels), std::end(const_labels),
-                   std::back_inserter(labels), gen);
-    std::transform(std::begin(more_labels), std::end(more_labels),
-                   std::back_inserter(labels), gen);
+                   std::back_inserter(labels), gen_pair);
+    if ( v == Variable::no ) {
+      std::transform(std::begin(more_labels), std::end(more_labels),
+                     std::back_inserter(labels), gen_pair);
+    }else {
+      std::transform(std::begin(variable_labels), std::end(variable_labels),
+                     std::back_inserter(labels), gen_vec);
+
+    }
 
     return labels;
   }
 
+  template <Variable v>
   void verifyCollectedLabels() {
     const auto collected = registry.Collect();
 
@@ -45,17 +60,45 @@ class BuilderTest : public testing::Test {
     EXPECT_EQ(help, collected.at(0).help);
     ASSERT_EQ(1U, collected.at(0).metric.size());
 
-    EXPECT_THAT(collected.at(0).metric.at(0).label,
-                testing::UnorderedElementsAreArray(expected_labels));
+    //    std::cout<<"===========got==========="<<std::endl;
+//    auto& l = collected.at(0).metric.at(0).label;
+//    std::for_each(l.begin(),l.end(),
+//                  [](const ClientMetric::Label& label){
+//                    std::cout<<label.name<<":"<<label.value<<std::endl;
+//                  });
+//    std::cout<<"===========end==========="<<std::endl;
+    if ( v == Variable::no) {
+//      std::cout<<"===========expected==========="<<std::endl;
+//      std::for_each(expected_labels.begin(),expected_variable_labels.end(),
+//                    [](const ClientMetric::Label& label){
+//                      std::cout<<label.name<<":"<<label.value<<std::endl;
+//                    });
+//      std::cout<<"=============end============="<<std::endl;
+      EXPECT_THAT(collected.at(0).metric.at(0).label,
+                  testing::UnorderedElementsAreArray(expected_labels));
+    } else {
+//      std::cout<<"===========expected==========="<<std::endl;
+//      std::for_each(expected_variable_labels.begin(),expected_variable_labels.end(),
+//                    [](const ClientMetric::Label& label){
+//                      std::cout<<label.name<<":"<<label.value<<std::endl;
+//                    });
+//      std::cout<<"=============end============="<<std::endl;
+
+      EXPECT_THAT(collected.at(0).metric.at(0).label,
+                  testing::UnorderedElementsAreArray(expected_variable_labels));
+    }
   }
 
   Registry registry;
 
   const std::string name = "some_name";
   const std::string help = "Additional description.";
+  const std::vector<std::string> variable_labels = {"vkey","vname"};
+  const std::vector<std::string> variable_values = {"vvalue","vtest"};
   const std::map<std::string, std::string> const_labels = {{"key", "value"}};
   const std::map<std::string, std::string> more_labels = {{"name", "test"}};
-  const std::vector<ClientMetric::Label> expected_labels = getExpectedLabels();
+  const std::vector<ClientMetric::Label> expected_labels = getExpectedLabels<Variable::no>();
+  const std::vector<ClientMetric::Label> expected_variable_labels = getExpectedLabels<Variable::yes>();
 };
 
 TEST_F(BuilderTest, build_counter) {
@@ -66,7 +109,7 @@ TEST_F(BuilderTest, build_counter) {
                      .Register(registry);
   family.Add(more_labels);
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
 }
 
 TEST_F(BuilderTest, build_gauge) {
@@ -77,7 +120,7 @@ TEST_F(BuilderTest, build_gauge) {
                      .Register(registry);
   family.Add(more_labels);
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
 }
 
 TEST_F(BuilderTest, build_histogram) {
@@ -88,7 +131,20 @@ TEST_F(BuilderTest, build_histogram) {
                      .Register(registry);
   family.Add(more_labels, Histogram::BucketBoundaries{1, 2});
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
+}
+
+TEST_F(BuilderTest, build_histogram_vec) {
+  auto& family = BuildHistogram()
+          .Name(name)
+          .Help(help)
+          .Labels(const_labels)
+          .LabelNamesVec(variable_labels)
+          .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
+          .Register(registry);
+  family.WithLabelValues(variable_values);
+
+  verifyCollectedLabels<Variable::yes>();
 }
 
 TEST_F(BuilderTest, build_summary) {
@@ -99,7 +155,20 @@ TEST_F(BuilderTest, build_summary) {
                      .Register(registry);
   family.Add(more_labels, Summary::Quantiles{});
 
-  verifyCollectedLabels();
+  verifyCollectedLabels<Variable::no>();
+}
+
+TEST_F(BuilderTest, build_summary_vec) {
+  auto& family = BuildSummary()
+          .Name(name)
+          .Help(help)
+          .Labels(const_labels)
+          .LabelNamesVec(variable_labels)
+          .Quantiles(Summary::Quantiles{})
+          .Register(registry);
+  family.WithLabelValues(variable_values);
+
+  verifyCollectedLabels<Variable::yes>();
 }
 
 }  // namespace

--- a/core/tests/family_test.cc
+++ b/core/tests/family_test.cc
@@ -28,6 +28,22 @@ TEST(FamilyTest, labels) {
               ::testing::ElementsAre(const_label, dynamic_label));
 }
 
+TEST(FamilyTest, variable_labels) {
+  auto const_label = ClientMetric::Label{"component", "test"};
+  auto dynamic_label = ClientMetric::Label{"status", "200"};
+
+  Family<Counter> family{"total_requests",
+                         "Counts all requests",
+                         {dynamic_label.name},
+                         {{const_label.name, const_label.value}}};
+  family.WithLabelValues({{dynamic_label.value}});
+  auto collected = family.Collect();
+  ASSERT_GE(collected.size(), 1U);
+  ASSERT_GE(collected.at(0).metric.size(), 1U);
+  EXPECT_THAT(collected.at(0).metric.at(0).label,
+              ::testing::ElementsAre(const_label, dynamic_label));
+}
+
 TEST(FamilyTest, reject_same_label_keys) {
   auto labels = std::map<std::string, std::string>{{"component", "test"}};
 
@@ -43,6 +59,24 @@ TEST(FamilyTest, counter_value) {
   ASSERT_GE(collected.size(), 1U);
   ASSERT_GE(collected[0].metric.size(), 1U);
   EXPECT_EQ(1, collected[0].metric.at(0).counter.value);
+}
+
+TEST(FamilyTest, variable_counter_value) {
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
+  auto& counter = family.WithLabelValues({});
+  counter.Increment();
+  auto collected = family.Collect();
+  ASSERT_GE(collected.size(), 1U);
+  ASSERT_GE(collected[0].metric.size(), 1U);
+  EXPECT_EQ(1, collected[0].metric.at(0).counter.value);
+}
+
+TEST(FamilyTest, should_assert_error_variable_value_size) {
+  Family<Counter> family{"total_requests", "Counts all requests", {}};
+  auto create_family_with_invalid_name = [&]() {
+    family.WithLabelValues({"haha"});
+  };
+  EXPECT_ANY_THROW(create_family_with_invalid_name());
 }
 
 TEST(FamilyTest, remove) {

--- a/pull/tests/integration/sample_server.cc
+++ b/pull/tests/integration/sample_server.cc
@@ -29,6 +29,8 @@ int main() {
   auto& packet_counter = BuildCounter()
                              .Name("observed_packets_total")
                              .Help("Number of observed packets")
+                             .Labels({{"label", "value"}})
+                             .LabelNamesVec({"label", "value"})
                              .Register(*registry);
 
   // add and remember dimensional data, incrementing those is very cheap
@@ -66,6 +68,7 @@ int main() {
     // dynamically calling Family<T>.Add() works but is slow and should be
     // avoided
     http_requests_counter.Add({{"method", method}}).Increment();
+    packet_counter.WithLabelValues({"v1", "v2"}).Increment();
   }
   return 0;
 }


### PR DESCRIPTION
we can use like this:
```c++
auto& family = BuildHistogram()
          .Name(name)
          .Help(help)
          .Labels(const_labels)
          .LabelNamesVec(variable_labels)
          .BucketBoundaries({Histogram::BucketBoundaries{1, 2}})
          .Register(registry);
  family.WithLabelValues(variable_values1).Observe(1.0);
  family.WithLabelValues(variable_values2).Observe(2.0);


  auto& family = BuildSummary()
          .Name(name)
          .Help(help)
          .Labels(const_labels)
          .LabelNamesVec(variable_labels)
          .Quantiles(Summary::Quantiles{})
          .Register(registry);
  family.WithLabelValues(variable_values1).Observe(1);
  family.WithLabelValues(variable_values2).Observe(2);
```