### PR TITLE
add method to query family if metric already exists

### DIFF
--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -119,6 +119,11 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   /// if the given metric was not returned by Add().
   void Remove(T* metric);
 
+  /// \brief Returns true if the dimensional data with the given labels exist
+  ///
+  /// \param labels A set of key-value pairs (= labels) of the dimensional data.
+  bool Has(const std::map<std::string, std::string>& labels) const;
+
   /// \brief Returns the name for this family.
   ///
   /// \return The family name.

--- a/core/src/family.cc
+++ b/core/src/family.cc
@@ -77,6 +77,13 @@ void Family<T>::Remove(T* metric) {
 }
 
 template <typename T>
+bool Family<T>::Has(const std::map<std::string, std::string>& labels) const {
+  auto hash = detail::hash_labels(labels);
+  std::lock_guard<std::mutex> lock{mutex_};
+  return metrics_.find(hash) != metrics_.end();
+}
+
+template <typename T>
 const std::string& Family<T>::GetName() const {
   return name_;
 }

--- a/core/tests/family_test.cc
+++ b/core/tests/family_test.cc
@@ -109,5 +109,12 @@ TEST(FamilyTest, should_not_collect_empty_metrics) {
   EXPECT_TRUE(collected.empty());
 }
 
+TEST(FamilyTest, query_family_if_metric_already_exists) {
+  Family<Counter> family{"total_rquests", "Counts all requests", {}};
+  family.Add({{"name", "counter1"}});
+  EXPECT_TRUE(family.Has({{"name", "counter1"}}));
+  EXPECT_FALSE(family.Has({{"name", "couner2"}}));
+}
+
 }  // namespace
 }  // namespace prometheus


### PR DESCRIPTION
If metrics are dynamically added and removed to and from a family (i.e. in a RAII way), there must only be only owner of the reference returned by the `family.Add()` method. To allow this we need to know if a metric with specific labels already exist within the family or likely end up with dangling references.

This relates to #178