### PR TITLE
CMakeLists: Change cmake min version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW) # recognize CMAKE_MSVC_RUNTIME_LIBRARY
 endif()


### PR DESCRIPTION
For cmake versions older than 3.14, the cpack generation fails at the
top level directory with the following:

CMake Error: The source directory "" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.

Using cmake 3.14 or newer fixes this.