### PR TITLE
Make summary quantiles non-const

### DIFF
--- a/cmake/googletest.imp
+++ b/cmake/googletest.imp
@@ -1,4 +1,5 @@
 [
   { include: [ "@<gmock/.*>", private, "<gmock/gmock.h>", public ] },
-  { include: [ "@<gtest/.*>", private, "<gtest/gtest.h>", public ] }
+  { include: [ "@<gtest/.*>", private, "<gtest/gtest.h>", public ] },
+  { include: [ "@<bits/this_thread_sleep.h>", private, "<thread>", public ]}
 ]

--- a/core/include/prometheus/detail/ckms_quantiles.h
+++ b/core/include/prometheus/detail/ckms_quantiles.h
@@ -15,21 +15,21 @@ namespace detail {
 class PROMETHEUS_CPP_CORE_EXPORT CKMSQuantiles {
  public:
   struct PROMETHEUS_CPP_CORE_EXPORT Quantile {
-    const double quantile;
-    const double error;
-    const double u;
-    const double v;
-
     Quantile(double quantile, double error);
+
+    double quantile;
+    double error;
+    double u;
+    double v;
   };
 
  private:
   struct Item {
-    /*const*/ double value;
+    double value;
     int g;
-    /*const*/ int delta;
+    int delta;
 
-    explicit Item(double value, int lower_delta, int delta);
+    Item(double value, int lower_delta, int delta);
   };
 
  public:

--- a/core/tests/summary_test.cc
+++ b/core/tests/summary_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <memory>
@@ -90,6 +91,14 @@ TEST(SummaryTest, max_age) {
   test_value(8.0);
   std::this_thread::sleep_for(std::chrono::milliseconds(600));
   test_value(std::numeric_limits<double>::quiet_NaN());
+}
+
+TEST(SummaryTest, construction_with_dynamic_quantile_vector) {
+  auto quantiles = Summary::Quantiles{{0.99, 0.001}};
+  quantiles.push_back({0.5, 0.05});
+
+  Summary summary{quantiles, std::chrono::seconds(1), 2};
+  summary.Observe(8.0);
 }
 
 }  // namespace


### PR DESCRIPTION
This change removes an unnecessary API constraint that makes it
harder to dynamically construct quantile configurations for summaries.

Fixes #425