### PR TITLE
rename library z to zlib

### DIFF
--- a/bazel/zlib.BUILD
+++ b/bazel/zlib.BUILD
@@ -3,7 +3,7 @@
 licenses(["notice"])  # BSD/MIT-like license (for zlib)
 
 cc_library(
-    name = "z",
+    name = "zlib",
     srcs = glob(["*.c"]),
     hdrs = glob(["*.h"]),
     # Use -Dverbose=-1 to turn off zlib's trace logging. (bazelbuild/bazel#3280)

--- a/pull/BUILD.bazel
+++ b/pull/BUILD.bazel
@@ -23,7 +23,7 @@ cc_library(
     deps = [
         "//core",
         "@civetweb",
-        "@net_zlib_zlib//:z",
+        "@net_zlib_zlib//:zlib",
     ],
 )
 


### PR DESCRIPTION
Rename zlib label name to compatable with other rules like `https://github.com/nelhage/rules_boost`