### PR TITLE
Bazel: "@net_zlib_zlib//:z" renamed to "@net_zlib_zlib//:zlib"

### DIFF
--- a/bazel/zlib.BUILD
+++ b/bazel/zlib.BUILD
@@ -3,7 +3,7 @@
 licenses(["notice"])  # BSD/MIT-like license (for zlib)
 
 cc_library(
-    name = "z",
+    name = "zlib",
     srcs = glob(["*.c"]),
     hdrs = glob(["*.h"]),
     # Use -Dverbose=-1 to turn off zlib's trace logging. (bazelbuild/bazel#3280)

--- a/pull/BUILD.bazel
+++ b/pull/BUILD.bazel
@@ -23,7 +23,7 @@ cc_library(
     deps = [
         "//core",
         "@civetweb",
-        "@net_zlib_zlib//:z",
+        "@net_zlib_zlib//:zlib",
     ],
 )
 


### PR DESCRIPTION
To be in consistent with `@net_zlib_zlib` package definition in [rules_boost](https://github.com/nelhage/rules_boost/blob/fce83babe3f6287bccb45d2df013a309fa3194b8/boost/boost.bzl).

```
Repository rule http_archive defined at:
  /home/story/.cache/bazel/_bazel_story/5f6cfd791ed6436cd7d0a9ad06515f99/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
ERROR: /home/story/.cache/bazel/_bazel_story/5f6cfd791ed6436cd7d0a9ad06515f99/external/boost/BUILD.bazel:810:14: no such target '@net_zlib_zlib//:zlib': target 'zlib' not declared in package '' defined by /home/story/.cache/bazel/_bazel_story/5f6cfd791ed6436cd7d0a9ad06515f99/external/net_zlib_zlib/BUILD.bazel and referenced by '@boost//:iostreams'
```