### PR TITLE
fix: there is a race condition when pushing and collecting histogram data

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <vector>
 
 #include "prometheus/client_metric.h"
@@ -68,6 +69,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
 
  private:
   const BucketBoundaries bucket_boundaries_;
+  mutable std::mutex mutex_;
   std::vector<Counter> bucket_counts_;
   Gauge sum_;
 };

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -24,6 +24,8 @@ void Histogram::Observe(const double value) {
       std::find_if(
           std::begin(bucket_boundaries_), std::end(bucket_boundaries_),
           [value](const double boundary) { return boundary >= value; })));
+
+  std::lock_guard<std::mutex> lock(mutex_);
   sum_.Increment(value);
   bucket_counts_[bucket_index].Increment();
 }
@@ -36,6 +38,7 @@ void Histogram::ObserveMultiple(const std::vector<double>& bucket_increments,
         "the number of buckets in the histogram.");
   }
 
+  std::lock_guard<std::mutex> lock(mutex_);
   sum_.Increment(sum_of_values);
 
   for (std::size_t i{0}; i < bucket_counts_.size(); ++i) {
@@ -44,6 +47,8 @@ void Histogram::ObserveMultiple(const std::vector<double>& bucket_increments,
 }
 
 ClientMetric Histogram::Collect() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
   auto metric = ClientMetric{};
 
   auto cumulative_count = 0ULL;


### PR DESCRIPTION
The rest of the library is written in a thread-safe way so I guess the non-thread-safe code in the histogram is a bug.

All increment counters and the total sum can be changed by another threads while the collection thread is preparing the cumulative data collection.  
This will result in an invalid scrape that can even contain pink elephants. 