### PR TITLE
Rule of Five applied on Gateway, avoid unnecessary copies of std::string

### DIFF
--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -19,9 +19,15 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
  public:
   using Labels = std::map<std::string, std::string>;
 
-  Gateway(const std::string host, const std::string port,
-          const std::string jobname, const Labels& labels = {},
-          const std::string username = {}, const std::string password = {});
+  Gateway(const std::string& host, const std::string& port,
+          const std::string& jobname, const Labels& labels = {},
+          const std::string& username = {}, const std::string& password = {});
+
+  Gateway(const Gateway&) = delete;
+  Gateway(Gateway&&) = delete;
+  Gateway& operator=(const Gateway&) = delete;
+  Gateway& operator=(Gateway&&) = delete;
+
   ~Gateway();
 
   void RegisterCollectable(const std::weak_ptr<Collectable>& collectable,

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -23,6 +23,13 @@ static const char CONTENT_TYPE[] =
 
 class CurlWrapper {
  public:
+  CurlWrapper() noexcept = default;
+
+  CurlWrapper(const CurlWrapper&) = delete;
+  CurlWrapper(CurlWrapper&&) = delete;
+  CurlWrapper& operator=(const CurlWrapper&) = delete;
+  CurlWrapper& operator=(CurlWrapper&&) = delete;
+
   ~CurlWrapper() { curl_easy_cleanup(curl_); }
 
   CURL* curl() {
@@ -36,9 +43,9 @@ class CurlWrapper {
   CURL* curl_ = nullptr;
 };
 
-Gateway::Gateway(const std::string host, const std::string port,
-                 const std::string jobname, const Labels& labels,
-                 const std::string username, const std::string password) {
+Gateway::Gateway(const std::string& host, const std::string& port,
+                 const std::string& jobname, const Labels& labels,
+                 const std::string& username, const std::string& password) {
   /* In windows, this will init the winsock stuff */
   curl_global_init(CURL_GLOBAL_ALL);
   curlWrapper_ = detail::make_unique<CurlWrapper>();


### PR DESCRIPTION
Pass `std::string` by reference instead of copy (is there a reason why we copy strings here that I missed?).
Explicitly delete special members of `Gateway` class to respect rule of five