### PR TITLE
Add new constructor for Histogram and Summary taking rvalue ref of parameters

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -44,7 +44,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   /// exponential etc..
   ///
   /// The bucket boundaries cannot be changed once the histogram is created.
-  Histogram(const BucketBoundaries& buckets);
+  explicit Histogram(const BucketBoundaries& buckets);
+
+  explicit Histogram(BucketBoundaries&& buckets);
 
   /// \brief Observe the given amount.
   ///
@@ -68,7 +70,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   ClientMetric Collect() const;
 
  private:
-  const BucketBoundaries bucket_boundaries_;
+  BucketBoundaries bucket_boundaries_;
   mutable std::mutex mutex_;
   std::vector<Counter> bucket_counts_;
   Gauge sum_;

--- a/core/include/prometheus/summary.h
+++ b/core/include/prometheus/summary.h
@@ -71,9 +71,13 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
   /// and how smooth the time window is moved. With only one age bucket it
   /// effectively results in a complete reset of the summary each time max_age
   /// has passed. The default value is 5.
-  Summary(const Quantiles& quantiles,
-          std::chrono::milliseconds max_age = std::chrono::seconds{60},
-          int age_buckets = 5);
+  explicit Summary(const Quantiles& quantiles,
+                   std::chrono::milliseconds max_age = std::chrono::seconds{60},
+                   int age_buckets = 5);
+
+  explicit Summary(Quantiles&& quantiles,
+                   std::chrono::milliseconds max_age = std::chrono::seconds{60},
+                   int age_buckets = 5);
 
   /// \brief Observe the given amount.
   void Observe(double value);
@@ -84,10 +88,10 @@ class PROMETHEUS_CPP_CORE_EXPORT Summary {
   ClientMetric Collect() const;
 
  private:
-  const Quantiles quantiles_;
+  Quantiles quantiles_;
   mutable std::mutex mutex_;
-  std::uint64_t count_;
-  double sum_;
+  std::uint64_t count_{};
+  double sum_{};
   detail::TimeWindowQuantiles quantile_values_;
 };
 

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -23,7 +23,15 @@ bool is_strict_sorted(ForwardIterator first, ForwardIterator last) {
 }  // namespace
 
 Histogram::Histogram(const BucketBoundaries& buckets)
-    : bucket_boundaries_{buckets}, bucket_counts_{buckets.size() + 1}, sum_{} {
+    : bucket_boundaries_{buckets}, bucket_counts_{buckets.size() + 1} {
+  if (!is_strict_sorted(begin(bucket_boundaries_), end(bucket_boundaries_))) {
+    throw std::invalid_argument("Bucket Boundaries must be strictly sorted");
+  }
+}
+
+Histogram::Histogram(BucketBoundaries&& buckets)
+    : bucket_boundaries_{std::move(buckets)},
+      bucket_counts_{bucket_boundaries_.size() + 1} {
   if (!is_strict_sorted(begin(bucket_boundaries_), end(bucket_boundaries_))) {
     throw std::invalid_argument("Bucket Boundaries must be strictly sorted");
   }

--- a/core/src/summary.cc
+++ b/core/src/summary.cc
@@ -7,8 +7,11 @@ namespace prometheus {
 Summary::Summary(const Quantiles& quantiles,
                  const std::chrono::milliseconds max_age, const int age_buckets)
     : quantiles_{quantiles},
-      count_{0},
-      sum_{0},
+      quantile_values_{quantiles_, max_age, age_buckets} {}
+
+Summary::Summary(Quantiles&& quantiles, const std::chrono::milliseconds max_age,
+                 const int age_buckets)
+    : quantiles_{std::move(quantiles)},
       quantile_values_{quantiles_, max_age, age_buckets} {}
 
 void Summary::Observe(const double value) {


### PR DESCRIPTION
- Set default values to object fields in header file to limit code duplication as well.
- Mark constructors taking only one parameter as explicit