### PR TITLE
Set clang-format to always left align references and pointers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: Google
+DerivePointerAlignment: false

--- a/core/src/detail/hash.h
+++ b/core/src/detail/hash.h
@@ -11,14 +11,14 @@ namespace detail {
 /// It's the boundary condition of this serial functions.
 ///
 /// \param seed Not effect.
-inline void hash_combine(std::size_t *) {}
+inline void hash_combine(std::size_t*) {}
 
 /// \brief Combine the given hash value with another obeject.
 ///
 /// \param seed The given hash value. It's a input/output parameter.
 /// \param value The object that will be combined with the given hash value.
 template <typename T>
-inline void hash_combine(std::size_t *seed, const T &value) {
+inline void hash_combine(std::size_t* seed, const T& value) {
   *seed ^= std::hash<T>{}(value) + 0x9e3779b9 + (*seed << 6) + (*seed >> 2);
 }
 
@@ -28,8 +28,8 @@ inline void hash_combine(std::size_t *seed, const T &value) {
 /// \param value The object that will be combined with the given hash value.
 /// \param args The objects that will be combined with the given hash value.
 template <typename T, typename... Types>
-inline void hash_combine(std::size_t *seed, const T &value,
-                         const Types &...args) {
+inline void hash_combine(std::size_t* seed, const T& value,
+                         const Types&... args) {
   hash_combine(seed, value);
   hash_combine(seed, args...);
 }
@@ -39,7 +39,7 @@ inline void hash_combine(std::size_t *seed, const T &value,
 /// \param args The arguments that will be computed hash value.
 /// \return The hash value of the given args.
 template <typename... Types>
-inline std::size_t hash_value(const Types &...args) {
+inline std::size_t hash_value(const Types&... args) {
   std::size_t seed = 0;
   hash_combine(&seed, args...);
   return seed;

--- a/core/src/serializer.cc
+++ b/core/src/serializer.cc
@@ -5,7 +5,7 @@
 namespace prometheus {
 
 std::string Serializer::Serialize(
-    const std::vector<MetricFamily> &metrics) const {
+    const std::vector<MetricFamily>& metrics) const {
   std::ostringstream ss;
   Serialize(ss, metrics);
   return ss.str();


### PR DESCRIPTION
While working on our fork I noticed an annoying issue where clang-format wasn't consistently left aligning references and pointers. I only noticed this as our own code uses right aligned style so I was doing that by habit until I noticed the a mix of alignment.

It seems by default `clang-format` will try to derive the alignment based on what it finds already in a file. I changed the `.clang-format` to force always left aligned and it found a few files with mixed alignment.