### PR TITLE
Add missing std:: on size_t

### DIFF
--- a/core/src/detail/utils.cc
+++ b/core/src/detail/utils.cc
@@ -1,5 +1,6 @@
 #include "prometheus/detail/utils.h"
 
+#include <cstddef>
 #include <map>
 #include <utility>
 
@@ -10,7 +11,7 @@ namespace prometheus {
 namespace detail {
 
 std::size_t LabelHasher::operator()(const Labels& labels) const {
-  size_t seed = 0;
+  std::size_t seed = 0;
   for (auto& label : labels) {
     hash_combine(&seed, label.first, label.second);
   }

--- a/pull/tests/integration/integration_test.cc
+++ b/pull/tests/integration/integration_test.cc
@@ -86,11 +86,11 @@ class IntegrationTest : public testing::Test {
   std::string default_metrics_path_ = "/metrics";
 
  private:
-  static size_t WriteCallback(void* contents, size_t size, size_t nmemb,
-                              void* userp) {
+  static std::size_t WriteCallback(void* contents, std::size_t size,
+                                   std::size_t nmemb, void* userp) {
     auto response = reinterpret_cast<std::string*>(userp);
 
-    size_t realsize = size * nmemb;
+    std::size_t realsize = size * nmemb;
     response->append(reinterpret_cast<const char*>(contents), realsize);
     return realsize;
   }


### PR DESCRIPTION
Noticed two files where `size_t` was used without the `std::` namespace.