### PR TITLE
Fix IWYU issues

### DIFF
--- a/core/include/prometheus/detail/builder.h
+++ b/core/include/prometheus/detail/builder.h
@@ -6,6 +6,7 @@
 
 // IWYU pragma: private
 // IWYU pragma: no_include "prometheus/family.h"
+// IWYU pragma: no_include "prometheus/registry.h"
 
 namespace prometheus {
 

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -11,12 +11,16 @@
 #include "prometheus/labels.h"
 #include "prometheus/metric_family.h"
 
+// IWYU pragma: no_include "prometheus/counter.h"
+// IWYU pragma: no_include "prometheus/gauge.h"
+// IWYU pragma: no_include "prometheus/histogram.h"
+// IWYU pragma: no_include "prometheus/summary.h"
 namespace prometheus {
 
-class Counter;
-class Gauge;
-class Histogram;
-class Summary;
+class Counter;    // IWYU pragma: keep
+class Gauge;      // IWYU pragma: keep
+class Histogram;  // IWYU pragma: keep
+class Summary;    // IWYU pragma: keep
 
 namespace detail {
 

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -2,6 +2,7 @@
 
 #include "prometheus/counter.h"
 #include "prometheus/detail/core_export.h"
+#include "prometheus/family.h"
 #include "prometheus/gauge.h"
 #include "prometheus/histogram.h"
 #include "prometheus/registry.h"

--- a/core/src/detail/time_window_quantiles.cc
+++ b/core/src/detail/time_window_quantiles.cc
@@ -1,7 +1,6 @@
 #include "prometheus/detail/time_window_quantiles.h"  // IWYU pragma: export
 
 #include <memory>
-#include <ratio>
 
 namespace prometheus {
 namespace detail {

--- a/core/src/detail/utils.cc
+++ b/core/src/detail/utils.cc
@@ -1,9 +1,9 @@
 #include "prometheus/detail/utils.h"
 
-#include <map>
-#include <utility>
-
 #include "hash.h"
+
+// IWYU pragma: no_include <string>
+// IWYU pragma: no_include <utility>
 
 namespace prometheus {
 

--- a/core/src/family.cc
+++ b/core/src/family.cc
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <map>
 #include <stdexcept>
-#include <type_traits>
 #include <utility>
 
 #include "prometheus/check_names.h"

--- a/pull/include/prometheus/exposer.h
+++ b/pull/include/prometheus/exposer.h
@@ -9,14 +9,15 @@
 
 #include "prometheus/collectable.h"
 #include "prometheus/detail/pull_export.h"
+// IWYU pragma: no_include "CivetServer.h"
 
-class CivetServer;
-struct CivetCallbacks;
+class CivetServer;      // IWYU pragma: keep
+struct CivetCallbacks;  // IWYU pragma: keep
 
 namespace prometheus {
 
 namespace detail {
-class Endpoint;
+class Endpoint;  // IWYU pragma: keep
 }  // namespace detail
 
 class PROMETHEUS_CPP_PULL_EXPORT Exposer {

--- a/pull/src/endpoint.h
+++ b/pull/src/endpoint.h
@@ -9,9 +9,11 @@
 #include "prometheus/collectable.h"
 #include "prometheus/registry.h"
 
+// IWYU pragma: no_include "handler.h"
+
 namespace prometheus {
 namespace detail {
-class MetricsHandler;
+class MetricsHandler;  // IWYU pragma: keep
 
 class Endpoint {
  public:

--- a/pull/src/handler.cc
+++ b/pull/src/handler.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstring>
 #include <iterator>
 #include <string>

--- a/pull/src/metrics_collector.h
+++ b/pull/src/metrics_collector.h
@@ -5,8 +5,10 @@
 
 #include "prometheus/metric_family.h"
 
+// IWYU pragma: no_include "prometheus/collectable.h"
+
 namespace prometheus {
-class Collectable;
+class Collectable;  // IWYU pragma: keep
 namespace detail {
 std::vector<prometheus::MetricFamily> CollectMetrics(
     const std::vector<std::weak_ptr<prometheus::Collectable>>& collectables);

--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -15,7 +15,7 @@
 namespace prometheus {
 
 namespace detail {
-class CurlWrapper;
+class CurlWrapper;  // IWYU pragma: keep
 }
 
 class PROMETHEUS_CPP_PUSH_EXPORT Gateway {

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <iterator>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <sstream>


### PR DESCRIPTION
I was checking some changes in our fork with IWYU and it seems to pick up a lot of issues with master.

I want to check that I am using the correct version of IWYU in case if it an issue of old version. The version I am using is the one in Ubuntu 20.04:
```
iwyu --version
include-what-you-use 0.12 based on clang version 9.0.1-10 
```

Otherwise this PR fixes most of the issues it finds except for two that I can't figure out how to fix. I am not very familiar with this tool.

The remaining issues:
```
/home/leith/swift/prometheus-cpp/pull/include/prometheus/exposer.h should add these lines:
#include "/home/leith/swift/prometheus-cpp/pull/src/endpoint.h"  // for Endp...

/home/leith/swift/prometheus-cpp/push/include/prometheus/gateway.h should add these lines:
#include "/home/leith/swift/prometheus-cpp/push/src/curl_wrapper.h"
```