### PR TITLE
Fix incorrect doc reference to "counter" in histogram.h

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -62,7 +62,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   void ObserveMultiple(const std::vector<double>& bucket_increments,
                        const double sum_of_values);
 
-  /// \brief Get the current value of the counter.
+  /// \brief Get the current value of the histogram.
   ///
   /// Collect is called by the Registry when collecting metrics.
   ClientMetric Collect() const;


### PR DESCRIPTION
I spotted this small mistake in `histogram.h`