### PR TITLE
test(core): prevent rotation on slow CPUs

### DIFF
--- a/core/tests/summary_test.cc
+++ b/core/tests/summary_test.cc
@@ -56,9 +56,10 @@ TEST(SummaryTest, quantile_bounds) {
 }
 
 TEST(SummaryTest, quantile_values) {
-  static const int SAMPLES = 1000000;
+  static const int SAMPLES = 100000;
 
-  Summary summary{Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}}};
+  Summary summary{Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}},
+                  std::chrono::hours{1}};  // prevent rotation on slow CPUs
   for (int i = 1; i <= SAMPLES; ++i) summary.Observe(i);
 
   auto metric = summary.Collect();


### PR DESCRIPTION
The Debian Sparc64 builds fail because the expected values
were not within their range:

```
[ RUN      ] SummaryTest.quantile_values
 /home/gjasny/prometheus-cpp/core/tests/summary_test.cc:68: Failure
The difference between s.quantile.at(0).value and 0.5 * SAMPLES is 317823, which exceeds 0.05 * SAMPLES, where
s.quantile.at(0).value evaluates to 817823,
0.5 * SAMPLES evaluates to 500000, and
0.05 * SAMPLES evaluates to 50000.
/home/gjasny/prometheus-cpp/core/tests/summary_test.cc:69: Failure
The difference between s.quantile.at(1).value and 0.9 * SAMPLES is 63818, which exceeds 0.01 * SAMPLES, where
s.quantile.at(1).value evaluates to 963818,
0.9 * SAMPLES evaluates to 900000, and
0.01 * SAMPLES evaluates to 10000.
/home/gjasny/prometheus-cpp/core/tests/summary_test.cc:70: Failure
The difference between s.quantile.at(2).value and 0.99 * SAMPLES is 6685, which exceeds 0.001 * SAMPLES, where
s.quantile.at(2).value evaluates to 996685,
0.99 * SAMPLES evaluates to 990000, and
0.001 * SAMPLES evaluates to 1000.
[  FAILED  ] SummaryTest.quantile_values (152010 ms)
```

The reason was that the TimeWindowQuantiles rotated through
the buckets due to the long runtime.