### PR TITLE
feat(core): Add Info metric

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(core
   src/family.cc
   src/gauge.cc
   src/histogram.cc
+  src/info.cc
   src/registry.cc
   src/serializer.cc
   src/summary.cc

--- a/core/benchmarks/CMakeLists.txt
+++ b/core/benchmarks/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(benchmarks
   counter_bench.cc
   gauge_bench.cc
   histogram_bench.cc
+  info_bench.cc
   registry_bench.cc
   summary_bench.cc
 )

--- a/core/benchmarks/info_bench.cc
+++ b/core/benchmarks/info_bench.cc
@@ -1,0 +1,20 @@
+#include <benchmark/benchmark.h>
+
+#include "prometheus/family.h"
+#include "prometheus/info.h"
+#include "prometheus/registry.h"
+
+static void BM_Info_Collect(benchmark::State& state) {
+  using prometheus::BuildInfo;
+  using prometheus::Info;
+  using prometheus::Registry;
+  Registry registry;
+  auto& info_family =
+      BuildInfo().Name("benchmark_info").Help("").Register(registry);
+  auto& info = info_family.Add({});
+
+  while (state.KeepRunning()) {
+    benchmark::DoNotOptimize(info.Collect());
+  };
+}
+BENCHMARK(BM_Info_Collect);

--- a/core/include/prometheus/client_metric.h
+++ b/core/include/prometheus/client_metric.h
@@ -40,6 +40,13 @@ struct PROMETHEUS_CPP_CORE_EXPORT ClientMetric {
   };
   Gauge gauge;
 
+  // Info
+
+  struct Info {
+    double value = 1.0;
+  };
+  Info info;
+
   // Summary
 
   struct Quantile {

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -16,6 +16,7 @@
 // IWYU pragma: no_include "prometheus/counter.h"
 // IWYU pragma: no_include "prometheus/gauge.h"
 // IWYU pragma: no_include "prometheus/histogram.h"
+// IWYU pragma: no_include "prometheus/info.h"
 // IWYU pragma: no_include "prometheus/summary.h"
 
 namespace prometheus {

--- a/core/include/prometheus/info.h
+++ b/core/include/prometheus/info.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "prometheus/client_metric.h"
+#include "prometheus/detail/builder.h"  // IWYU pragma: export
+#include "prometheus/detail/core_export.h"
+#include "prometheus/metric_type.h"
+
+namespace prometheus {
+
+/// \brief A info metric to represent textual information which should not
+/// change during process lifetime.
+///
+/// This class represents the metric type info:
+/// https://github.com/OpenObservability/OpenMetrics/blob/98ae26c87b1c3bcf937909a880b32c8be643cc9b/specification/OpenMetrics.md#info
+
+/// Prometheus does not provide this type directly, it is used by emulating a
+/// gauge with value 1: https://prometheus.io/docs/concepts/metric_types/#gauge
+///
+/// The value of the info cannot change. Example of infos are:
+/// - the application's version
+/// - revision control commit
+/// - version of the compiler
+///
+/// The class is thread-safe. No concurrent call to any API of this type causes
+/// a data race.
+class PROMETHEUS_CPP_CORE_EXPORT Info {
+ public:
+  static const MetricType metric_type{MetricType::Info};
+
+  /// \brief Create a info.
+  Info() = default;
+
+  /// \brief Get the current value of the info.
+  ///
+  /// Collect is called by the Registry when collecting metrics.
+  ClientMetric Collect() const;
+};
+
+/// \brief Return a builder to configure and register a Info metric.
+///
+/// @copydetails Family<>::Family()
+///
+/// Example usage:
+///
+/// \code
+/// auto registry = std::make_shared<Registry>();
+/// auto& info_family = prometheus::BuildInfo()
+///                            .Name("some_name")
+///                            .Help("Additional description.")
+///                            .Labels({{"key", "value"}})
+///                            .Register(*registry);
+///
+/// ...
+/// \endcode
+///
+/// \return An object of unspecified type T, i.e., an implementation detail
+/// except that it has the following members:
+///
+/// - Name(const std::string&) to set the metric name,
+/// - Help(const std::string&) to set an additional description.
+/// - Labels(const Labels&) to assign a set of
+///   key-value pairs (= labels) to the metric.
+///
+/// To finish the configuration of the Info metric, register it with
+/// Register(Registry&).
+PROMETHEUS_CPP_CORE_EXPORT detail::Builder<Info> BuildInfo();
+
+}  // namespace prometheus

--- a/core/include/prometheus/metric_type.h
+++ b/core/include/prometheus/metric_type.h
@@ -8,6 +8,7 @@ enum class MetricType {
   Summary,
   Untyped,
   Histogram,
+  Info,
 };
 
 }  // namespace prometheus

--- a/core/include/prometheus/registry.h
+++ b/core/include/prometheus/registry.h
@@ -16,6 +16,7 @@ namespace prometheus {
 class Counter;
 class Gauge;
 class Histogram;
+class Info;
 class Summary;
 
 namespace detail {
@@ -33,7 +34,7 @@ class Builder;  // IWYU pragma: keep
 /// that returns zero or more metrics and their samples. The metrics are
 /// represented by the class Family<>, which implements the Collectable
 /// interface. A new metric is registered with BuildCounter(), BuildGauge(),
-/// BuildHistogram() or BuildSummary().
+/// BuildHistogram(), BuildInfo() or BuildSummary().
 ///
 /// The class is thread-safe. No concurrent call to any API of this type causes
 /// a data race.
@@ -111,6 +112,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Registry : public Collectable {
   std::vector<std::unique_ptr<Family<Counter>>> counters_;
   std::vector<std::unique_ptr<Family<Gauge>>> gauges_;
   std::vector<std::unique_ptr<Family<Histogram>>> histograms_;
+  std::vector<std::unique_ptr<Family<Info>>> infos_;
   std::vector<std::unique_ptr<Family<Summary>>> summaries_;
   mutable std::mutex mutex_;
 };

--- a/core/src/detail/builder.cc
+++ b/core/src/detail/builder.cc
@@ -4,6 +4,7 @@
 #include "prometheus/detail/core_export.h"
 #include "prometheus/gauge.h"
 #include "prometheus/histogram.h"
+#include "prometheus/info.h"
 #include "prometheus/registry.h"
 #include "prometheus/summary.h"
 
@@ -37,6 +38,7 @@ Family<T>& Builder<T>::Register(Registry& registry) {
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Counter>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Gauge>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Histogram>;
+template class PROMETHEUS_CPP_CORE_EXPORT Builder<Info>;
 template class PROMETHEUS_CPP_CORE_EXPORT Builder<Summary>;
 
 }  // namespace detail
@@ -44,6 +46,7 @@ template class PROMETHEUS_CPP_CORE_EXPORT Builder<Summary>;
 detail::Builder<Counter> BuildCounter() { return {}; }
 detail::Builder<Gauge> BuildGauge() { return {}; }
 detail::Builder<Histogram> BuildHistogram() { return {}; }
+detail::Builder<Info> BuildInfo() { return {}; }
 detail::Builder<Summary> BuildSummary() { return {}; }
 
 }  // namespace prometheus

--- a/core/src/family.cc
+++ b/core/src/family.cc
@@ -11,6 +11,7 @@
 #include "prometheus/counter.h"
 #include "prometheus/gauge.h"
 #include "prometheus/histogram.h"
+#include "prometheus/info.h"
 #include "prometheus/summary.h"
 
 namespace prometheus {
@@ -124,6 +125,7 @@ ClientMetric Family<T>::CollectMetric(const Labels& metric_labels,
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Counter>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Gauge>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Histogram>;
+template class PROMETHEUS_CPP_CORE_EXPORT Family<Info>;
 template class PROMETHEUS_CPP_CORE_EXPORT Family<Summary>;
 
 }  // namespace prometheus

--- a/core/src/info.cc
+++ b/core/src/info.cc
@@ -1,0 +1,11 @@
+#include "prometheus/info.h"
+
+namespace prometheus {
+
+ClientMetric Info::Collect() const {
+  ClientMetric metric;
+  metric.info.value = 1;
+  return metric;
+}
+
+}  // namespace prometheus

--- a/core/src/text_serializer.cc
+++ b/core/src/text_serializer.cc
@@ -96,6 +96,13 @@ void SerializeGauge(std::ostream& out, const MetricFamily& family,
   WriteTail(out, metric);
 }
 
+void SerializeInfo(std::ostream& out, const MetricFamily& family,
+                   const ClientMetric& metric) {
+  WriteHead(out, family, metric, "_info");
+  WriteValue(out, metric.info.value);
+  WriteTail(out, metric);
+}
+
 void SerializeSummary(std::ostream& out, const MetricFamily& family,
                       const ClientMetric& metric) {
   auto& sum = metric.summary;
@@ -162,6 +169,14 @@ void SerializeFamily(std::ostream& out, const MetricFamily& family) {
       out << "# TYPE " << family.name << " gauge\n";
       for (auto& metric : family.metric) {
         SerializeGauge(out, family, metric);
+      }
+      break;
+    // info is not handled by prometheus, we use gauge as workaround
+    // (https://github.com/OpenObservability/OpenMetrics/blob/98ae26c87b1c3bcf937909a880b32c8be643cc9b/specification/OpenMetrics.md#info-1)
+    case MetricType::Info:
+      out << "# TYPE " << family.name << " gauge\n";
+      for (auto& metric : family.metric) {
+        SerializeInfo(out, family, metric);
       }
       break;
     case MetricType::Summary:

--- a/core/tests/builder_test.cc
+++ b/core/tests/builder_test.cc
@@ -14,6 +14,7 @@
 #include "prometheus/family.h"
 #include "prometheus/gauge.h"
 #include "prometheus/histogram.h"
+#include "prometheus/info.h"
 #include "prometheus/labels.h"
 #include "prometheus/registry.h"
 #include "prometheus/summary.h"
@@ -88,6 +89,14 @@ TEST_F(BuilderTest, build_histogram) {
                      .Labels(const_labels)
                      .Register(registry);
   family.Add(more_labels, Histogram::BucketBoundaries{1, 2});
+
+  verifyCollectedLabels();
+}
+
+TEST_F(BuilderTest, build_info) {
+  auto& family =
+      BuildInfo().Name(name).Help(help).Labels(const_labels).Register(registry);
+  family.Add(more_labels);
 
   verifyCollectedLabels();
 }

--- a/core/tests/check_label_name_test.cc
+++ b/core/tests/check_label_name_test.cc
@@ -43,7 +43,7 @@ TEST_P(CheckLabelNameTest, reject_quantile_for_histogram) {
 INSTANTIATE_TEST_SUITE_P(AllMetricTypes, CheckLabelNameTest,
                          testing::Values(MetricType::Counter, MetricType::Gauge,
                                          MetricType::Histogram,
-                                         MetricType::Summary,
+                                         MetricType::Info, MetricType::Summary,
                                          MetricType::Untyped));
 
 }  // namespace

--- a/core/tests/registry_test.cc
+++ b/core/tests/registry_test.cc
@@ -8,6 +8,7 @@
 #include "prometheus/counter.h"
 #include "prometheus/gauge.h"
 #include "prometheus/histogram.h"
+#include "prometheus/info.h"
 #include "prometheus/summary.h"
 
 namespace prometheus {
@@ -62,6 +63,7 @@ TEST(RegistryTest, reject_different_type_than_counter) {
   EXPECT_NO_THROW(BuildCounter().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildGauge().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildHistogram().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildInfo().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildSummary().Name(same_name).Register(registry));
 }
 
@@ -72,6 +74,7 @@ TEST(RegistryTest, reject_different_type_than_gauge) {
   EXPECT_NO_THROW(BuildGauge().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildCounter().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildHistogram().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildInfo().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildSummary().Name(same_name).Register(registry));
 }
 
@@ -80,9 +83,21 @@ TEST(RegistryTest, reject_different_type_than_histogram) {
   Registry registry{};
 
   EXPECT_NO_THROW(BuildHistogram().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildInfo().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildCounter().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildGauge().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildSummary().Name(same_name).Register(registry));
+}
+
+TEST(RegistryTest, reject_different_type_than_info) {
+  const auto same_name = std::string{"same_name"};
+  Registry registry{};
+
+  EXPECT_NO_THROW(BuildInfo().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildCounter().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildGauge().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildSummary().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildHistogram().Name(same_name).Register(registry));
 }
 
 TEST(RegistryTest, reject_different_type_than_summary) {
@@ -93,6 +108,7 @@ TEST(RegistryTest, reject_different_type_than_summary) {
   EXPECT_ANY_THROW(BuildCounter().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildGauge().Name(same_name).Register(registry));
   EXPECT_ANY_THROW(BuildHistogram().Name(same_name).Register(registry));
+  EXPECT_ANY_THROW(BuildInfo().Name(same_name).Register(registry));
 }
 
 TEST(RegistryTest, throw_for_same_family_name) {

--- a/core/tests/text_serializer_test.cc
+++ b/core/tests/text_serializer_test.cc
@@ -9,6 +9,7 @@
 
 #include "prometheus/client_metric.h"
 #include "prometheus/histogram.h"
+#include "prometheus/info.h"
 #include "prometheus/metric_family.h"
 #include "prometheus/metric_type.h"
 #include "prometheus/summary.h"
@@ -105,6 +106,14 @@ TEST_F(TextSerializerTest, shouldSerializeHistogram) {
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_bucket{le=\"1\"} 1\n"));
   EXPECT_THAT(serialized,
               testing::HasSubstr(name + "_bucket{le=\"+Inf\"} 2\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeInfo) {
+  Info info;
+  metric = info.Collect();
+
+  const auto serialized = Serialize(MetricType::Info);
+  EXPECT_THAT(serialized, testing::HasSubstr(name + "_info 1"));
 }
 
 TEST_F(TextSerializerTest, shouldSerializeSummary) {

--- a/pull/tests/integration/sample_server.cc
+++ b/pull/tests/integration/sample_server.cc
@@ -9,6 +9,7 @@
 #include "prometheus/counter.h"
 #include "prometheus/exposer.h"
 #include "prometheus/family.h"
+#include "prometheus/info.h"
 #include "prometheus/registry.h"
 
 int main() {
@@ -49,6 +50,11 @@ int main() {
                                     .Help("Number of HTTP requests")
                                     .Register(*registry);
 
+  auto& version_info = BuildInfo()
+                           .Name("versions")
+                           .Help("Static info about the library")
+                           .Register(*registry);
+  version_info.Add({{"prometheus", "1.0"}});
   // ask the exposer to scrape the registry on incoming HTTP requests
   exposer.RegisterCollectable(registry);
 


### PR DESCRIPTION
Hi,

Info is a metric type defined in the [OpenMetrics format](https://github.com/OpenObservability/OpenMetrics/blob/98ae26c87b1c3bcf937909a880b32c8be643cc9b/specification/OpenMetrics.md#info).

It allows to use labels for static information that will not change during the lifetime (for example, versions of the executable/librairies, compilation date...).

In prometheus, it is emulated using a [Gauge with a value 1](https://github.com/prometheus/prometheus/blob/2ce94ac19673a3f7faf164e9e078a79d4d52b767/cmd/promtool/testdata/metrics-test.prom#L33-L35).

After checking, it is not implemented in all the clients, but I've found it in the [Java](https://github.com/prometheus/client_java/blob/2b60c479f57a2f1e20a5bab4dc7131df42327da7/simpleclient/src/main/java/io/prometheus/client/Info.java), [Python](https://github.com/prometheus/client_python#info) and [Rust](https://github.com/prometheus/client_rust/blob/master/src/metrics.rs#L20) implementations.

Cheers,

Johnny

ps: I couldn't run iwyu yet, I have issues installing it.