### PR TITLE
Add Reset APIs to histogram and counters

### DIFF
--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -38,6 +38,9 @@ class PROMETHEUS_CPP_CORE_EXPORT Counter {
   /// The counter will not change if the given amount is negative.
   void Increment(double);
 
+  /// \brief Reset the counter to 0
+  void Reset();
+
   /// \brief Get the current value of the counter.
   double Value() const;
 

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -65,6 +65,12 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   void ObserveMultiple(const std::vector<double>& bucket_increments,
                        double sum_of_values);
 
+  /// \brief Reset all data points collected so far.
+  ///
+  /// All buckets and sum are reset to its oringal value. This is especially
+  /// useful if histogram is tracked elsewhere but report in prometheus system.
+  void Reset();
+
   /// \brief Get the current value of the histogram.
   ///
   /// Collect is called by the Registry when collecting metrics.

--- a/core/src/counter.cc
+++ b/core/src/counter.cc
@@ -13,6 +13,8 @@ void Counter::Increment(const double val) {
 
 double Counter::Value() const { return gauge_.Value(); }
 
+void Counter::Reset() { gauge_.Set(0); }
+
 ClientMetric Counter::Collect() const {
   ClientMetric metric;
   metric.counter.value = Value();

--- a/core/src/histogram.cc
+++ b/core/src/histogram.cc
@@ -64,6 +64,14 @@ void Histogram::ObserveMultiple(const std::vector<double>& bucket_increments,
   }
 }
 
+void Histogram::Reset() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (std::size_t i = 0; i < bucket_counts_.size(); ++i) {
+    bucket_counts_[i].Reset();
+  }
+  sum_.Set(0);
+}
+
 ClientMetric Histogram::Collect() const {
   std::lock_guard<std::mutex> lock(mutex_);
 

--- a/core/tests/counter_test.cc
+++ b/core/tests/counter_test.cc
@@ -37,5 +37,15 @@ TEST(CounterTest, inc_negative_value) {
   EXPECT_EQ(counter.Value(), 5.0);
 }
 
+TEST(CounterTest, reset) {
+  Counter counter;
+  counter.Increment();
+  counter.Reset();
+  EXPECT_EQ(counter.Value(), 0.0);
+  counter.Increment(5);
+  counter.Increment();
+  EXPECT_EQ(counter.Value(), 6.0);
+}
+
 }  // namespace
 }  // namespace prometheus

--- a/core/tests/histogram_test.cc
+++ b/core/tests/histogram_test.cc
@@ -118,6 +118,26 @@ TEST(HistogramTest, observe_multiple_test_length_error) {
   ASSERT_THROW(histogram.ObserveMultiple({5, 9}, 20), std::length_error);
 }
 
+TEST(HistogramTest, test_reset) {
+  Histogram histogram{{1, 2}};
+  histogram.ObserveMultiple({5, 9, 3}, 20);
+  histogram.ObserveMultiple({0, 20, 6}, 34);
+  histogram.Reset();
+  auto metric = histogram.Collect();
+  auto h = metric.histogram;
+  EXPECT_EQ(h.sample_count, 0U);
+  EXPECT_EQ(h.sample_sum, 0U);
+  EXPECT_EQ(h.bucket.at(0).cumulative_count, 0U);
+  EXPECT_EQ(h.bucket.at(1).cumulative_count, 0U);
+  EXPECT_EQ(h.bucket.at(2).cumulative_count, 0U);
+  histogram.ObserveMultiple({5, 9, 3}, 20);
+  histogram.ObserveMultiple({0, 20, 6}, 34);
+  metric = histogram.Collect();
+  h = metric.histogram;
+  EXPECT_EQ(h.sample_count, 43U);
+  EXPECT_EQ(h.sample_sum, 54);
+}
+
 TEST(HistogramTest, sum_can_go_down) {
   Histogram histogram{{1}};
   auto metric1 = histogram.Collect();


### PR DESCRIPTION
These reset apis are specifically useful when histograms are collected from different way and then convert them to prometheus metric.