### PR TITLE
chore(push): use zlib 1.2.13

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -48,12 +48,12 @@ def prometheus_cpp_repositories():
     maybe(
         http_archive,
         name = "net_zlib_zlib",
-        sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
-        strip_prefix = "zlib-1.2.12",
+        sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+        strip_prefix = "zlib-1.2.13",
         urls = [
-            "https://mirror.bazel.build/zlib.net/zlib-1.2.12.tar.gz",
-            "https://zlib.net/zlib-1.2.12.tar.gz",
-            "https://storage.googleapis.com/bazel-mirror/zlib.net/zlib-1.2.12.tar.gz",
+            "https://mirror.bazel.build/zlib.net/zlib-1.2.13.tar.gz",
+            "https://zlib.net/zlib-1.2.13.tar.gz",
+            "https://storage.googleapis.com/bazel-mirror/zlib.net/zlib-1.2.13.tar.gz",
         ],
         build_file = "@com_github_jupp0r_prometheus_cpp//bazel:zlib.BUILD",
     )


### PR DESCRIPTION
1.2.13 contains a fix for critical CVE https://nvd.nist.gov/vuln/detail/CVE-2022-37434