### PR TITLE
Update platform constraints to be compatible with bazel 6

### DIFF
--- a/bazel/civetweb.BUILD
+++ b/bazel/civetweb.BUILD
@@ -3,14 +3,14 @@ licenses(["notice"])  # MIT license
 config_setting(
     name = "osx",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
 )
 
 config_setting(
     name = "windows",
     constraint_values = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
 )
 

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -23,7 +23,7 @@ package(features = ["no_copts_tokenization"])
 config_setting(
     name = "windows",
     constraint_values = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     visibility = ["//visibility:private"],
 )
@@ -31,7 +31,7 @@ config_setting(
 config_setting(
     name = "osx",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
Bazel 6 flipped the incompatible_use_platforms_repo_for_constraints flag
which causes `@bazel_tools//platforms:*` constraints to fail. The fix is to
use the constraints from `@platforms//*`.

See https://github.com/bazelbuild/bazel/issues/8622 for more details.

Signed-off-by: Vihang Mehta <vihang@pixielabs.ai>
