### PR TITLE
feat(core): histograms: support observing values a non-integral number of times

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -49,19 +49,29 @@ class PROMETHEUS_CPP_CORE_EXPORT Histogram {
   /// \copydoc Histogram::Histogram(const BucketBoundaries&)
   explicit Histogram(BucketBoundaries&& buckets);
 
-  /// \brief Observe the given amount.
+  /// \brief Observe the given value.
   ///
-  /// The given amount selects the 'observed' bucket. The observed bucket is
-  /// chosen for which the given amount falls into the half-open interval [b_n,
-  /// b_n+1). The counter of the observed bucket is incremented. Also the total
-  /// sum of all observations is incremented.
-  void Observe(double value);
+  /// The given value selects the 'observed' bucket. The observed bucket is
+  /// chosen for which the given value falls into the half-open interval [b_n,
+  /// b_n+1). The counter of the observed bucket is incremented by the given
+  /// quantity. Also the total sum of all observations is incremented by
+  /// value*quantity.
+  ///
+  /// Passing a quantity!=1 can be seen as a generalization for real numbers of
+  /// calling Observe(value, 1) in a loop. The collected bucket counts will be
+  /// truncated but resulting rounding errors (other than those caused by
+  /// summing floating points) will not accumulate over time nor over cumulative
+  /// bucket counts. Same for the cumulative sum of the histogram.
+  void Observe(double value, double quantity = 1.0);
 
   /// \brief Observe multiple data points.
   ///
   /// Increments counters given a count for each bucket. (i.e. the caller of
   /// this function must have already sorted the values into buckets).
   /// Also increments the total sum of all observations by the given value.
+  ///
+  /// See the details in Observe(double, double) about floats when passing
+  /// non-integer values as bucket increments.
   void ObserveMultiple(const std::vector<double>& bucket_increments,
                        double sum_of_values);
 


### PR DESCRIPTION
Observing a given value multiple times can be performed either by calling Observe multiple times or calling ObserveMultiple. The latter option is not very convenient because the caller has to keep track of existing buckets and perform bucketization.

Observing a given value a non-integral number of times can also be done using ObserveMultiple (even though that was probably not intended) because the bucket_increments argument is a vector of doubles. It can't be done by calling Observe because you can't call a function a fraction of a time.

Accumulating non-integral counts in buckets makes sense if what you are measuring is dimensionful: e.g. keeping track of how long (in seconds) an object is moving at certain (bucketed) speeds. If you observe that the object has moved at speed X for 1.5s, you'll want to increase the bucket corresponding to X by 1.5.

This commit adds an argument to Observe (defaulting to 1.0 for backward compatibility) that makes it possible increment the bucket corresponding to the value by a non-integral quantity. It can be seen as a generalization of calling Observe in a loop, for a non-integral number of times. The count is incremented by the quantity and sum is incremented by value * quantity to preserve the semantic of the count and of the sum (and then of the computed mean), which is also consistent with what would happen if Observe was called in a loop.