### PR TITLE
build(cmake): rpm package via custom spec file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(THIRDPARTY_CIVETWEB_WITH_SSL "Enable SSL support for embedded civetweb so
 option(OVERRIDE_CXX_STANDARD_FLAGS "Force building with -std=c++11 even if the CXXFLAGS are configured differently" ON)
 option(GENERATE_PKGCONFIG "Generate and install pkg-config files" ${UNIX})
 option(RUN_IWYU "Run include-what-you-use" OFF)
+option(ENABLE_RPM_SPEC "Create rpm package using custom spec" OFF)
 
 if(OVERRIDE_CXX_STANDARD_FLAGS)
   set(CMAKE_CXX_STANDARD 11)
@@ -176,8 +177,60 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
   set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
-  set(CPACK_RPM_PACKAGE_AUTOREQPROV ON)
-  set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
+  # rpm packaging
+  if(ENABLE_RPM_SPEC)
+    set(CPACK_SOURCE_GENERATOR "TGZ")
+    set(CPACK_SOURCE_PACKAGE_FILE_NAME
+      "${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+    string(TIMESTAMP RPMDATE "%a %b %d %Y")
+
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}.spec.cmake.in"
+      ${PROJECT_NAME}.spec
+    )
+
+    add_custom_command(OUTPUT "${CPACK_SOURCE_PACKAGE_FILE_NAME}.tar.gz"
+      COMMAND ${CMAKE_MAKE_PROGRAM} package_source
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    )
+
+    add_custom_target(rpm-source-tgz
+      DEPENDS "${CPACK_SOURCE_PACKAGE_FILE_NAME}.tar.gz"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+      VERBATIM
+    )
+
+    add_custom_target(rpm-prebuild
+      COMMAND ${CMAKE_COMMAND} -E make_directory rpmbuild
+      COMMAND ${CMAKE_COMMAND} -E make_directory rpmbuild/BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory rpmbuild/BUILDROOT
+      COMMAND ${CMAKE_COMMAND} -E make_directory rpmbuild/RPMS
+      COMMAND ${CMAKE_COMMAND} -E make_directory rpmbuild/SOURCES
+      COMMAND ${CMAKE_COMMAND} -E make_directory rpmbuild/SPECS
+      COMMAND ${CMAKE_COMMAND} -E make_directory rpmbuild/SRPMS
+      COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_NAME}.spec" rpmbuild/SPECS
+      COMMAND ${CMAKE_COMMAND} -E copy "${CPACK_SOURCE_PACKAGE_FILE_NAME}.tar.gz" rpmbuild/SOURCES
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+      DEPENDS rpm-source-tgz
+      VERBATIM
+    )
+
+    string(CONCAT RPMBUILD_COMMAND "rpmbuild -ba --define "
+      "\"_topdir ${CMAKE_CURRENT_BINARY_DIR}/rpmbuild\" "
+      "rpmbuild/SPECS/${PROJECT_NAME}.spec"
+    )
+
+    add_custom_target(rpm
+      COMMAND sh -c "${RPMBUILD_COMMAND}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+      DEPENDS rpm-prebuild
+      COMMENT "Create rpm package"
+      VERBATIM
+    )
+  else()
+    set(CPACK_RPM_PACKAGE_AUTOREQPROV ON)
+    set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
+  endif()
 
   include(CPack)
 endif()

--- a/README.md
+++ b/README.md
@@ -200,7 +200,24 @@ cmake --build _build --target package --parallel $(nproc)
 
 This will place an appropriately named .deb in the
 `_build` folder. To build a RPM package set the `CPACK_GENERATOR`
-variable to `RPM`. 
+variable to `RPM`.
+
+Alternatively, rpm packages may be build by using a dedicated spec file and custom
+`rpm` target:
+
+``` shell
+# fetch third-party dependencies
+git submodule update --init
+
+# run cmake
+cmake -B_build -DENABLE_RPM_SPEC=ON -DBUILD_SHARED_LIBS=ON
+
+# build rpm package via custom target
+cmake --build _build --target rpm
+...
+ls _build/rpmbuild/RPMS/$(uname -m)/*.rpm
+
+```
 
 ## Consuming the installed project
 

--- a/cmake/prometheus-cpp.spec.cmake.in
+++ b/cmake/prometheus-cpp.spec.cmake.in
@@ -1,0 +1,64 @@
+%undefine _debugsource_packages
+%undefine _debuginfo_subpackages
+
+Name:           @CMAKE_PROJECT_NAME@
+Summary:        Prometheus Client Library for Modern C++
+Version:        @CMAKE_PROJECT_VERSION@
+Release:        1%{?dist}
+License:        MIT
+Group:          Development/Libraries
+Vendor:         The prometheus-cpp authors
+Url:            @CMAKE_PROJECT_HOMEPAGE_URL@
+Source:         @CPACK_SOURCE_PACKAGE_FILE_NAME@.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}.%{_arch}
+Requires:       libxcrypt
+BuildRequires:  cmake
+BuildRequires:  zlib-devel
+BuildRequires:  libcurl-devel
+
+%description
+This library aims to enable Metrics-Driven Development for C++ services. It
+implements the Prometheus Data Model, a powerful abstraction on which to
+collect and expose metrics. We offer the possibility for metrics to be
+collected by Prometheus, but other push/pull collections can be added as
+plugins.
+
+%package devel
+Summary: Prometheus Client Library C++ header files
+Group:          Development/Libraries
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+Development files for prometheus-cpp library.
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+%cmake -B %{_builddir} \
+  -DBUILD_SHARED_LIBS=ON \
+  -DGENERATE_PKGCONFIG=OFF \
+  -DCMAKE_INSTALL_PREFIX:PATH=%{buildroot}/usr
+
+%install
+cmake --build %{_builddir} --target install
+
+%clean
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/lib*.so.*
+%exclude %{_prefix}/lib/*
+%exclude %{_prefix}/src/*
+
+%files devel
+%defattr(-,root,root,-)
+%{_includedir}/prometheus/*
+%{_libdir}/lib*.so
+%{_libdir}/cmake/prometheus-cpp/prometheus-cpp*.cmake
+
+%changelog
+* @RPMDATE@ Shachar Sharon <ssharon@ibm.com> - @CMAKE_PROJECT_VERSION@-1
+  Prometheus-cpp rpm packaging
+
+


### PR DESCRIPTION
Provide a detailed RPM spec file and use it to generate rpm package via cmake build system. Although CPack knows how to create rpm packages, it produces low quality spec file. Instead, use dedicated spec file and generate rpm packages with custom target:

  $ cmake -B_build -DENABLE_RPM_SPEC=ON -DBUILD_SHARED_LIBS=ON
  $ cmake --build _build --target rpm