### PR TITLE
Encode empty push label values with '=' character.

### DIFF
--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -49,7 +49,10 @@ void Gateway::RegisterCollectable(const std::weak_ptr<Collectable>& collectable,
 
   if (labels) {
     for (auto& label : *labels) {
-      ss << "/" << label.first << "/" << label.second;
+      // A single = is required to encode an empty label value into a URL,
+      // see https://github.com/prometheus/pushgateway#url
+      auto value_url_segment = label.second.empty() ? "=" : label.second;
+      ss << "/" << label.first << "/" << value_url_segment;
     }
   }
 


### PR DESCRIPTION
Pushgateway encodes grouping label keys and values as URL path segments. Those values may be blank, but URL path segments may not be blank. To get around this, pushgateway requires that empty values be encoded as the character '='. See https://github.com/prometheus/pushgateway#url for details.

Fixes #652 