### PR TITLE
ci: disable Bazel on macOS for SSL build

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -30,12 +30,15 @@ jobs:
         run: brew install telegraf
 
       - name: Build with SSL
+        if: runner.os != 'macOS'
         run: bazel build --config=ssl ${{ matrix.bazel_args }} //...
 
       - name: Test with SSL
+        if: runner.os != 'macOS'
         run: bazel test --config=ssl ${{ matrix.bazel_args }} --test_output=all //...
 
       - name: Build with SSL and bzlmod
+        if: runner.os != 'macOS'
         run: bazel build --enable_bzlmod --config=ssl ${{ matrix.bazel_args }} //...
 
       - name: Build


### PR DESCRIPTION
Bazel seems to ingest some OpenSSL headers from
/usr/local/include that collide with boringssl.