### PR TITLE
feat(push): allow timeout for HTTP requests

### DIFF
--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -22,7 +23,8 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
  public:
   Gateway(const std::string& host, const std::string& port,
           const std::string& jobname, const Labels& labels = {},
-          const std::string& username = {}, const std::string& password = {});
+          const std::string& username = {}, const std::string& password = {},
+          std::chrono::seconds timeout = {});
 
   Gateway(const Gateway&) = delete;
   Gateway(Gateway&&) = delete;
@@ -68,6 +70,7 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   std::string jobUri_;
   std::string labels_;
   std::unique_ptr<detail::CurlWrapper> curlWrapper_;
+  std::chrono::seconds timeout_;
   std::mutex mutex_;
 
   using CollectableEntry = std::pair<std::weak_ptr<Collectable>, std::string>;

--- a/push/src/detail/curl_wrapper.cc
+++ b/push/src/detail/curl_wrapper.cc
@@ -39,7 +39,7 @@ CurlWrapper::~CurlWrapper() {
 }
 
 int CurlWrapper::performHttpRequest(HttpMethod method, const std::string& uri,
-                                    const std::string& body) {
+                                    const std::string& body, long timeout) {
   std::lock_guard<std::mutex> l(mutex_);
 
   curl_easy_reset(curl_);
@@ -75,6 +75,8 @@ int CurlWrapper::performHttpRequest(HttpMethod method, const std::string& uri,
       curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "DELETE");
       break;
   }
+
+  curl_easy_setopt(curl_, CURLOPT_TIMEOUT, timeout);
 
   auto curl_error = curl_easy_perform(curl_);
 

--- a/push/src/detail/curl_wrapper.h
+++ b/push/src/detail/curl_wrapper.h
@@ -20,7 +20,7 @@ class CurlWrapper {
   ~CurlWrapper();
 
   int performHttpRequest(HttpMethod method, const std::string& uri,
-                         const std::string& body);
+                         const std::string& body, long timeout = 0L);
   bool addHttpHeader(const std::string& header);
 
  private:

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -21,7 +21,9 @@ namespace prometheus {
 
 Gateway::Gateway(const std::string& host, const std::string& port,
                  const std::string& jobname, const Labels& labels,
-                 const std::string& username, const std::string& password) {
+                 const std::string& username, const std::string& password,
+                 std::chrono::seconds timeout)
+    : timeout_(timeout) {
   curlWrapper_ = detail::make_unique<detail::CurlWrapper>(username, password);
 
   std::stringstream jobUriStream;
@@ -84,7 +86,8 @@ int Gateway::push(detail::HttpMethod method) {
     auto metrics = collectable->Collect();
     auto body = serializer.Serialize(metrics);
     auto uri = getUri(wcollectable);
-    auto status_code = curlWrapper_->performHttpRequest(method, uri, body);
+    auto status_code =
+        curlWrapper_->performHttpRequest(method, uri, body, timeout_.count());
 
     if (status_code < 100 || status_code >= 400) {
       return status_code;
@@ -118,7 +121,8 @@ std::future<int> Gateway::async_push(detail::HttpMethod method) {
     auto uri = getUri(wcollectable);
 
     futures.push_back(std::async(std::launch::async, [method, uri, body, this] {
-      return curlWrapper_->performHttpRequest(method, uri, *body);
+      return curlWrapper_->performHttpRequest(method, uri, *body,
+                                              timeout_.count());
     }));
   }
 
@@ -141,7 +145,7 @@ std::future<int> Gateway::async_push(detail::HttpMethod method) {
 
 int Gateway::Delete() {
   return curlWrapper_->performHttpRequest(detail::HttpMethod::Delete, jobUri_,
-                                          {});
+                                          {}, timeout_.count());
 }
 
 std::future<int> Gateway::AsyncDelete() {
@@ -149,8 +153,8 @@ std::future<int> Gateway::AsyncDelete() {
 }
 
 int Gateway::DeleteForInstance() {
-  return curlWrapper_->performHttpRequest(detail::HttpMethod::Delete,
-                                          jobUri_ + labels_, {});
+  return curlWrapper_->performHttpRequest(
+      detail::HttpMethod::Delete, jobUri_ + labels_, {}, timeout_.count());
 }
 
 std::future<int> Gateway::AsyncDeleteForInstance() {


### PR DESCRIPTION
Allows specification of a timeout for HTTP requests which is passed to curl. This allows the operation to eventually fail if the remote endpoint does not respond.

Default value for the added parameter maintains existing behaviour.