### PR TITLE
Move benchmark activation logic under ENABLE_TESTING

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -93,8 +93,8 @@ endif()
 
 if(ENABLE_TESTING)
   add_subdirectory(tests)
-endif()
 
-if(benchmark_FOUND)
-  add_subdirectory(benchmarks)
+  if(benchmark_FOUND)
+    add_subdirectory(benchmarks)
+  endif()
 endif()


### PR DESCRIPTION
This prevents accidental benchmarks activation if prometheus-cpp is used as a submodule of a larger project, that activates benchmarks library.