### PR TITLE
Add presetupCurl callback to Gateway.

### DIFF
--- a/cmake/prometheus-cpp-push.pc.in
+++ b/cmake/prometheus-cpp-push.pc.in
@@ -7,8 +7,8 @@ Name: @PROJECT_NAME@-push
 Description: @PROJECT_DESCRIPTION@
 URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: @PROJECT_NAME@-core
-Requires.private: @PKGCONFIG_REQUIRES@
+Requires: @PROJECT_NAME@-core @PKGCONFIG_REQUIRES@
+Requires.private:
 Cflags: -I${includedir}
 Libs: -L${libdir} -l@PROJECT_NAME@-push
 Libs.private: @CMAKE_THREAD_LIBS_INIT@ @PKGCONFIG_LIBS@

--- a/push/CMakeLists.txt
+++ b/push/CMakeLists.txt
@@ -20,10 +20,10 @@ target_compile_features(push
 target_link_libraries(push
   PUBLIC
     ${PROJECT_NAME}::core
+    CURL::libcurl
   PRIVATE
     ${PROJECT_NAME}::util
     Threads::Threads
-    CURL::libcurl
     $<$<AND:$<BOOL:UNIX>,$<NOT:$<BOOL:APPLE>>>:rt>
 )
 

--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -28,8 +28,11 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   Gateway(const std::string& host, const std::string& port,
           const std::string& jobname, const Labels& labels = {},
           const std::string& username = {}, const std::string& password = {},
-          std::chrono::seconds timeout = {},
-          std::function<void(CURL*)> presetupCurl = nullptr);
+          std::chrono::seconds timeout = {});
+
+  Gateway(const std::string& host, const std::string& port,
+          std::function<void(CURL*)> presetupCurl, const std::string& jobname,
+          const Labels& labels = {});
 
   Gateway(const Gateway&) = delete;
   Gateway(Gateway&&) = delete;
@@ -75,7 +78,6 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   std::string jobUri_;
   std::string labels_;
   std::unique_ptr<detail::CurlWrapper> curlWrapper_;
-  std::chrono::seconds timeout_;
   std::mutex mutex_;
 
   using CollectableEntry = std::pair<std::weak_ptr<Collectable>, std::string>;

--- a/push/include/prometheus/gateway.h
+++ b/push/include/prometheus/gateway.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <curl/curl.h>
+
 #include <chrono>
+#include <functional>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -13,6 +16,7 @@
 #include "prometheus/detail/push_export.h"
 #include "prometheus/labels.h"
 
+
 namespace prometheus {
 
 namespace detail {
@@ -24,7 +28,8 @@ class PROMETHEUS_CPP_PUSH_EXPORT Gateway {
   Gateway(const std::string& host, const std::string& port,
           const std::string& jobname, const Labels& labels = {},
           const std::string& username = {}, const std::string& password = {},
-          std::chrono::seconds timeout = {});
+          std::chrono::seconds timeout = {},
+          std::function<void(CURL*)> presetupCurl = nullptr);
 
   Gateway(const Gateway&) = delete;
   Gateway(Gateway&&) = delete;

--- a/push/src/detail/curl_wrapper.h
+++ b/push/src/detail/curl_wrapper.h
@@ -11,9 +11,7 @@ namespace detail {
 
 class CurlWrapper {
  public:
-  CurlWrapper(const std::string& username,
-              const std::string& password,
-              std::function<void(CURL*)> presetupCurl = nullptr);
+  CurlWrapper(std::function<void(CURL*)> presetupCurl);
 
   CurlWrapper(const CurlWrapper&) = delete;
   CurlWrapper(CurlWrapper&&) = delete;
@@ -23,12 +21,11 @@ class CurlWrapper {
   ~CurlWrapper();
 
   int performHttpRequest(HttpMethod method, const std::string& uri,
-                         const std::string& body, long timeout = 0L);
+                         const std::string& body = {});
   bool addHttpHeader(const std::string& header);
 
  private:
   CURL* curl_;
-  std::string auth_;
   std::mutex mutex_;
   curl_slist* optHttpHeader_;
   std::function<void(CURL*)> presetupCurl_;

--- a/push/src/detail/curl_wrapper.h
+++ b/push/src/detail/curl_wrapper.h
@@ -1,5 +1,6 @@
 #include <curl/curl.h>
 
+#include <functional>
 #include <mutex>
 #include <string>
 
@@ -10,7 +11,9 @@ namespace detail {
 
 class CurlWrapper {
  public:
-  CurlWrapper(const std::string& username, const std::string& password);
+  CurlWrapper(const std::string& username,
+              const std::string& password,
+              std::function<void(CURL*)> presetupCurl = nullptr);
 
   CurlWrapper(const CurlWrapper&) = delete;
   CurlWrapper(CurlWrapper&&) = delete;
@@ -28,6 +31,7 @@ class CurlWrapper {
   std::string auth_;
   std::mutex mutex_;
   curl_slist* optHttpHeader_;
+  std::function<void(CURL*)> presetupCurl_;
 };
 
 }  // namespace detail

--- a/push/src/gateway.cc
+++ b/push/src/gateway.cc
@@ -22,9 +22,12 @@ namespace prometheus {
 Gateway::Gateway(const std::string& host, const std::string& port,
                  const std::string& jobname, const Labels& labels,
                  const std::string& username, const std::string& password,
-                 std::chrono::seconds timeout)
+                 std::chrono::seconds timeout,
+                 std::function<void(CURL*)> presetupCurl)
     : timeout_(timeout) {
-  curlWrapper_ = detail::make_unique<detail::CurlWrapper>(username, password);
+  curlWrapper_ = detail::make_unique<detail::CurlWrapper>(username,
+                                                          password,
+                                                          presetupCurl);
 
   std::stringstream jobUriStream;
   jobUriStream << host << ':' << port << "/metrics";


### PR DESCRIPTION
I use self-signed certificate, so I need possibility to add extra options for curl.

For example, for disabling check ssl certificate I do:

```	
const prometheus::Labels Labels = prometheus::Gateway::GetInstanceLabel("https://pushgateway.prometheus.localhost");
prometheus::Gateway Gateway{
    "https://pushgateway.prometheus.localhost", "", "sample_client", Labels, {}, {}, {},
    [&](CURL* curl)
    {
        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
    }
};
```