### PR TITLE
Added two cmake cross compile toolchain file.

### DIFF
--- a/cmake/toolchain-aarch64.cmake
+++ b/cmake/toolchain-aarch64.cmake
@@ -1,0 +1,71 @@
+# **********************************************************
+# Copyright (c) 2014-2021 Google, Inc.    All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Google, Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# This toolchain file simply copyed from DynamoRIO project. And tested on    
+# Ubuntu 22.04 via docker.
+
+# For cross-compiling on aarch64 Linux using gcc-aarch64-linux-gnu package:
+# - install AArch64 tool chain:
+#   $ sudo apt-get install g++-aarch64-linux-gnu
+# - cross-compiling config
+#   $ cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-aarch64.cmake
+# You may have to set CMAKE_FIND_ROOT_PATH to point to the target enviroment, e.g.
+# by passing -DCMAKE_FIND_ROOT_PATH=/usr/aarch64-linux-gnu on Debian-like systems.
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(TARGET_ABI "linux-gnu")
+# specify the cross compiler
+SET(CMAKE_C_COMPILER   aarch64-${TARGET_ABI}-gcc)
+SET(CMAKE_CXX_COMPILER aarch64-${TARGET_ABI}-g++)
+
+# To build the tests, we need to set where the target environment containing
+# the required library is. On Debian-like systems, this is
+# /usr/aarch64-linux-gnu.
+SET(CMAKE_FIND_ROOT_PATH "/usr/aarch64-${TARGET_ABI}")
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Set additional variables.
+# If we don't set some of these, CMake will end up using the host version.
+# We want the full path, however, so we can pass EXISTS and other checks in
+# the our CMake code.
+find_program(GCC_FULL_PATH aarch64-${TARGET_ABI}-gcc)
+if (NOT GCC_FULL_PATH)
+  message(FATAL_ERROR "Cross-compiler aarch64-${TARGET_ABI}-gcc not found")
+endif ()
+get_filename_component(GCC_DIR ${GCC_FULL_PATH} PATH)
+SET(CMAKE_LINKER       ${GCC_DIR}/aarch64-${TARGET_ABI}-ld      CACHE FILEPATH "linker")
+SET(CMAKE_ASM_COMPILER ${GCC_DIR}/aarch64-${TARGET_ABI}-as      CACHE FILEPATH "assembler")
+SET(CMAKE_OBJCOPY      ${GCC_DIR}/aarch64-${TARGET_ABI}-objcopy CACHE FILEPATH "objcopy")
+SET(CMAKE_STRIP        ${GCC_DIR}/aarch64-${TARGET_ABI}-strip   CACHE FILEPATH "strip")
+SET(CMAKE_CPP          ${GCC_DIR}/aarch64-${TARGET_ABI}-cpp     CACHE FILEPATH "cpp")

--- a/cmake/toolchain-aarch64.cmake
+++ b/cmake/toolchain-aarch64.cmake
@@ -35,7 +35,7 @@
 # - install AArch64 tool chain:
 #   $ sudo apt-get install g++-aarch64-linux-gnu
 # - cross-compiling config
-#   $ cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-aarch64.cmake
+#   $  cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-aarch64.cmake
 # You may have to set CMAKE_FIND_ROOT_PATH to point to the target enviroment, e.g.
 # by passing -DCMAKE_FIND_ROOT_PATH=/usr/aarch64-linux-gnu on Debian-like systems.
 set(CMAKE_SYSTEM_NAME Linux)

--- a/cmake/toolchain-riscv64.cmake
+++ b/cmake/toolchain-riscv64.cmake
@@ -1,0 +1,71 @@
+# **********************************************************
+# Copyright (c) 2022 Rivos, Inc.    All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Rivos, Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# This toolchain file simply copyed from DynamoRIO project. And tested on    
+# Ubuntu 22.04 via docker.
+
+# For cross-compiling on riscv64 Linux using gcc-riscv64-linux-gnu package:
+# - install riscv64 toolchain:
+#   $ sudo apt-get install g++-riscv64-linux-gnu
+# - cross-compiling config
+#   $ cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-aarch64.cmake
+# You may have to set CMAKE_FIND_ROOT_PATH to point to the target enviroment, e.g.
+# by passing -DCMAKE_FIND_ROOT_PATH=/usr/riscv64-linux-gnu on Debian-like systems.
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+set(TARGET_ABI "linux-gnu")
+# specify the cross compiler
+SET(CMAKE_C_COMPILER   riscv64-${TARGET_ABI}-gcc)
+SET(CMAKE_CXX_COMPILER riscv64-${TARGET_ABI}-g++)
+
+# To build the tests, we need to set where the target environment containing
+# the required library is. On Debian-like systems, this is
+# /usr/riscv64-linux-gnu.
+SET(CMAKE_FIND_ROOT_PATH "/usr/riscv64-${TARGET_ABI}")
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Set additional variables.
+# If we don't set some of these, CMake will end up using the host version.
+# We want the full path, however, so we can pass EXISTS and other checks in
+# our CMake code.
+find_program(GCC_FULL_PATH riscv64-${TARGET_ABI}-gcc)
+if (NOT GCC_FULL_PATH)
+  message(FATAL_ERROR "Cross-compiler riscv64-${TARGET_ABI}-gcc not found")
+endif ()
+get_filename_component(GCC_DIR ${GCC_FULL_PATH} PATH)
+SET(CMAKE_LINKER       ${GCC_DIR}/riscv64-${TARGET_ABI}-ld      CACHE FILEPATH "linker")
+SET(CMAKE_ASM_COMPILER ${GCC_DIR}/riscv64-${TARGET_ABI}-as      CACHE FILEPATH "assembler")
+SET(CMAKE_OBJCOPY      ${GCC_DIR}/riscv64-${TARGET_ABI}-objcopy CACHE FILEPATH "objcopy")
+SET(CMAKE_STRIP        ${GCC_DIR}/riscv64-${TARGET_ABI}-strip   CACHE FILEPATH "strip")
+SET(CMAKE_CPP          ${GCC_DIR}/riscv64-${TARGET_ABI}-cpp     CACHE FILEPATH "cpp")

--- a/cmake/toolchain-riscv64.cmake
+++ b/cmake/toolchain-riscv64.cmake
@@ -35,7 +35,7 @@
 # - install riscv64 toolchain:
 #   $ sudo apt-get install g++-riscv64-linux-gnu
 # - cross-compiling config
-#   $ cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-aarch64.cmake
+#   $  cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-riscv64.cmake
 # You may have to set CMAKE_FIND_ROOT_PATH to point to the target enviroment, e.g.
 # by passing -DCMAKE_FIND_ROOT_PATH=/usr/riscv64-linux-gnu on Debian-like systems.
 set(CMAKE_SYSTEM_NAME Linux)


### PR DESCRIPTION
This commit includes RISC-V and AArch64 cross-compile support for Prometheus-cpp.

Full steps:

```bash
git submodule init
git submodule update

mkdir aarch64_build
cd aarch64_build

# run cmake with cross-compile toolchain
cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-aarch64.cmake

# build
cmake --build . --parallel 4

# test
Test should runs on QEMU. WIP