### PR TITLE
Use curl as bazel_dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,12 +8,13 @@ data_deps_ext = use_extension("//bazel:repositories.bzl", "data_deps_ext")
 use_repo(
     data_deps_ext,
     "civetweb",
-    "com_github_curl",
 )
 
 bazel_dep(name = "boringssl", version = "0.0.0-20230215-5c22014")
-bazel_dep(name = "google_benchmark", version = "1.8.3", dev_dependency = True, repo_name = "com_github_google_benchmark")
-bazel_dep(name = "googletest", version = "1.12.1", dev_dependency = True, repo_name = "com_google_googletest")
+bazel_dep(name = "curl", version = "8.7.1", repo_name = "com_github_curl")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "zlib", version = "1.3")
+
+bazel_dep(name = "google_benchmark", version = "1.8.3", dev_dependency = True, repo_name = "com_github_google_benchmark")
+bazel_dep(name = "googletest", version = "1.12.1", dev_dependency = True, repo_name = "com_google_googletest")


### PR DESCRIPTION
Curl has been publish as a bzlmod.
This use it as a bazel_dep instead of bazel extension

I also used buildifier to format MODULE.bazel and placed dev_dependencies after build dependencies