### PR TITLE
Add config for basic package version file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,12 @@ install(
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
+write_basic_package_version_file(
+  "${PROJECT_NAME}-config-version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in"
   ${PROJECT_NAME}-config.cmake
@@ -155,7 +161,7 @@ configure_package_config_file(
 )
 
 install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 

--- a/cmake/project-import-cmake/CMakeLists.txt
+++ b/cmake/project-import-cmake/CMakeLists.txt
@@ -4,6 +4,10 @@ project(prometheus-cpp-import)
 
 find_package(prometheus-cpp CONFIG REQUIRED)
 
+if(NOT DEFINED prometheus-cpp_VERSION)
+  message(FATAL_ERROR "prometheus-cpp_VERSION is not defined")
+endif()
+
 if(PROMETHEUS_CPP_ENABLE_PUSH)
   add_executable(sample-client sample_client.cc)
   target_link_libraries(sample-client PRIVATE prometheus-cpp::push $<$<BOOL:${WIN32}>:Ws2_32>)


### PR DESCRIPTION
Added CMake config to automatically generate version information file. This makes it possible to check if the correct version of the package is installed when the package is consumed.

I'm not sure if the COMPATIBILITY parameter is the one that fits this library best. 
If you like this change and want to merge it just change it to the value you want.