### PR TITLE
build(bazel): Add support for --incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,13 @@
-build:asan --strip=never 
+# Make globs that don't match anything fail
+common --incompatible_disallow_empty_glob
+
+build:asan --strip=never
 build:asan --copt -fsanitize=address
 build:asan --copt -DADDRESS_SANITIZER
 build:asan --copt -O0
 build:asan --copt -fno-omit-frame-pointer
 build:asan --copt -g
-build:asan --linkopt -fsanitize=address 
+build:asan --linkopt -fsanitize=address
 build:asan --cc_output_directory_tag=asan
 
 build:ssl --define=with_civetweb_ssl=true

--- a/pull/BUILD.bazel
+++ b/pull/BUILD.bazel
@@ -27,15 +27,3 @@ cc_library(
         "@zlib",
     ],
 )
-
-cc_library(
-    name = "pull_internal_headers",
-    hdrs = glob(
-        ["src/detail/*.h"],
-    ),
-    strip_include_prefix = "src",
-    visibility = ["//pull/tests:__subpackages__"],
-    deps = [
-        "//core",
-    ],
-)

--- a/pull/tests/unit/BUILD.bazel
+++ b/pull/tests/unit/BUILD.bazel
@@ -1,9 +1,6 @@
 cc_test(
     name = "unit",
-    srcs = glob([
-        "*.cc",
-        "*.h",
-    ]),
+    srcs = glob(["*.cc"]),
     copts = ["-Iexternal/googletest/include"],
     linkstatic = True,
     deps = [

--- a/push/tests/internal/BUILD.bazel
+++ b/push/tests/internal/BUILD.bazel
@@ -1,9 +1,6 @@
 cc_test(
     name = "internal",
-    srcs = glob([
-        "*.cc",
-        "*.h",
-    ]),
+    srcs = glob(["*.cc"]),
     copts = ["-Iexternal/googletest/include"],
     linkstatic = True,
     deps = [

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,12 +1,6 @@
 cc_library(
     name = "util",
-    srcs = glob([
-        "src/**/*.cc",
-        "src/**/*.h",
-    ]),
-    hdrs = glob(
-        ["include/**/*.h"],
-    ),
+    hdrs = glob(["include/**/*.h"]),
     strip_include_prefix = "include",
     visibility = ["//:__subpackages__"],
 )

--- a/util/tests/unit/BUILD.bazel
+++ b/util/tests/unit/BUILD.bazel
@@ -1,9 +1,6 @@
 cc_test(
     name = "unit",
-    srcs = glob([
-        "*.cc",
-        "*.h",
-    ]),
+    srcs = glob(["*.cc"]),
     copts = ["-Iexternal/googletest/include"],
     linkstatic = True,
     deps = [


### PR DESCRIPTION
This flag helps find accidental misconfigurations with invalid globs earlier. It's expected to become the default in the next major version of bazel. The BUILD file changes here allow downstream consumers to enable it now.