### PR TITLE
fix incorrect document for  family.h

### DIFF
--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -88,7 +88,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   /// \param constant_labels Assign a set of key-value pairs (= labels) to the
   /// metric. All these labels are propagated to each time series within the
   /// metric.
-  /// \throw std::runtime_exception on invalid metric or label names.
+  /// \throw std::invalid_argument on invalid metric or label names.
   Family(const std::string& name, const std::string& help,
          const Labels& constant_labels);
 
@@ -108,7 +108,7 @@ class PROMETHEUS_CPP_CORE_EXPORT Family : public Collectable {
   /// Counter, Gauge, Histogram or Summary for required constructor arguments.
   /// \return Return the newly created dimensional data or - if a same set of
   /// labels already exists - the already existing dimensional data.
-  /// \throw std::runtime_exception on invalid label names.
+  /// \throw std::invalid_argument on invalid label names.
   template <typename... Args>
   T& Add(const Labels& labels, Args&&... args) {
     return Add(labels, detail::make_unique<T>(args...));


### PR DESCRIPTION
I fixed incorrect description, which is mentioned [here](https://github.com/jupp0r/prometheus-cpp/issues/636).

`Family()` constructor  and `Add()` method raises `std::invalid_argument` exception, but the document `family.h` says `\throw std::runtime_exception on invalid metric or label names.`